### PR TITLE
Add load balancer protocol support

### DIFF
--- a/cosmic/resource_cosmic_loadbalancer_rule.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule.go
@@ -65,6 +65,16 @@ func resourceCosmicLoadBalancerRule() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					switch v {
+					case "tcp", "tcp-proxy":
+					default:
+						errs = append(errs, fmt.Errorf("%q must be either 'tcp' or 'tcp-proxy', got: %q", key, v))
+					}
+
+					return
+				},
 			},
 
 			"member_ids": &schema.Schema{
@@ -86,11 +96,6 @@ func resourceCosmicLoadBalancerRule() *schema.Resource {
 
 func resourceCosmicLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cosmic.CosmicClient)
-
-	// Make sure all required parameters are there
-	if err := verifyLoadBalancerRule(d); err != nil {
-		return err
-	}
 
 	d.Partial(true)
 
@@ -253,21 +258,6 @@ func resourceCosmicLoadBalancerRuleDelete(d *schema.ResourceData, meta interface
 			"Invalid parameter id value=%s due to incorrect long value format, "+
 				"or entity does not exist", d.Id())) {
 			return err
-		}
-	}
-
-	return nil
-}
-
-func verifyLoadBalancerRule(d *schema.ResourceData) error {
-	if protocol, ok := d.GetOk("protocol"); ok {
-		protocol := protocol.(string)
-
-		switch protocol {
-		case "tcp", "tcp-proxy":
-		default:
-			return fmt.Errorf(
-				"%q is not a valid protocol. Valid options are 'tcp' and 'tcp-proxy'", protocol)
 		}
 	}
 

--- a/cosmic/resource_cosmic_loadbalancer_rule_test.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule_test.go
@@ -108,6 +108,8 @@ func TestAccCosmicLoadBalancerRule_forceNew(t *testing.T) {
 						"cosmic_loadbalancer_rule.foo", "public_port", "443"),
 					resource.TestCheckResourceAttr(
 						"cosmic_loadbalancer_rule.foo", "private_port", "443"),
+					resource.TestCheckResourceAttr(
+						"cosmic_loadbalancer_rule.foo", "protocol", "tcp-proxy"),
 				),
 			},
 		},
@@ -307,6 +309,7 @@ resource "cosmic_loadbalancer_rule" "foo" {
   algorithm = "leastconn"
   public_port = 443
   private_port = 443
+  protocol = "tcp-proxy"
   member_ids = ["${cosmic_instance.foobar1.id}"]
 }
 `,


### PR DESCRIPTION
Add `protocol` argument to `cosmic_load_balancer_rule` so the protocol can be selected. As Cosmic only supports the `tcp` and `tcp-proxy` protocols a check has been added for this.

Based on the code from the CloudStack provider.