### PR TITLE
Update xanzy refs in project

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -354,7 +354,7 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/xanzy/terraform-provider-cosmic"
+  name = "github.com/MissionCriticalCloud/terraform-provider-cosmic"
   packages = ["cosmic"]
   revision = "88ebb610560c0a9daef3725ec13370619661beb7"
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/MissionCriticalCloud/terraform-provider-cosmic/cosmic"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/xanzy/terraform-provider-cosmic/cosmic"
 )
 
 func main() {


### PR DESCRIPTION
As this repo was moved to the MissionCriticalCloud org we should update "xanzy" references to "MissionCriticalCloud".