### PR TITLE
Save correct case to state

### DIFF
--- a/cosmic/resource_cosmic_instance.go
+++ b/cosmic/resource_cosmic_instance.go
@@ -120,6 +120,9 @@ func resourceCosmicInstance() *schema.Resource {
 			"optimise_for": {
 				Type:     schema.TypeString,
 				Optional: true,
+				StateFunc: func(val interface{}) string {
+					return strings.Title(strings.ToLower(val.(string)))
+				},
 			},
 
 			"expunge": {


### PR DESCRIPTION
We already have the correct casing sent to the API but we should also
store this in the state.  If someone later changed the casing in the
plan it would come up as a change causing an instance restart.