### PR TITLE
Add support for resource importers

### DIFF
--- a/cosmic/resource_cosmic_affinity_group.go
+++ b/cosmic/resource_cosmic_affinity_group.go
@@ -14,6 +14,9 @@ func resourceCosmicAffinityGroup() *schema.Resource {
 		Create: resourceCosmicAffinityGroupCreate,
 		Read:   resourceCosmicAffinityGroupRead,
 		Delete: resourceCosmicAffinityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_disk.go
+++ b/cosmic/resource_cosmic_disk.go
@@ -14,6 +14,9 @@ func resourceCosmicDisk() *schema.Resource {
 		Read:   resourceCosmicDiskRead,
 		Update: resourceCosmicDiskUpdate,
 		Delete: resourceCosmicDiskDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_egress_firewall.go
+++ b/cosmic/resource_cosmic_egress_firewall.go
@@ -18,6 +18,9 @@ func resourceCosmicEgressFirewall() *schema.Resource {
 		Read:   resourceCosmicEgressFirewallRead,
 		Update: resourceCosmicEgressFirewallUpdate,
 		Delete: resourceCosmicEgressFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"network_id": &schema.Schema{

--- a/cosmic/resource_cosmic_firewall.go
+++ b/cosmic/resource_cosmic_firewall.go
@@ -18,6 +18,9 @@ func resourceCosmicFirewall() *schema.Resource {
 		Read:   resourceCosmicFirewallRead,
 		Update: resourceCosmicFirewallUpdate,
 		Delete: resourceCosmicFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cosmic/resource_cosmic_instance.go
+++ b/cosmic/resource_cosmic_instance.go
@@ -18,6 +18,9 @@ func resourceCosmicInstance() *schema.Resource {
 		Read:   resourceCosmicInstanceRead,
 		Update: resourceCosmicInstanceUpdate,
 		Delete: resourceCosmicInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/cosmic/resource_cosmic_loadbalancer_rule.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule.go
@@ -15,6 +15,9 @@ func resourceCosmicLoadBalancerRule() *schema.Resource {
 		Read:   resourceCosmicLoadBalancerRuleRead,
 		Update: resourceCosmicLoadBalancerRuleUpdate,
 		Delete: resourceCosmicLoadBalancerRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_network.go
+++ b/cosmic/resource_cosmic_network.go
@@ -37,6 +37,9 @@ func resourceCosmicNetwork() *schema.Resource {
 		Read:   resourceCosmicNetworkRead,
 		Update: resourceCosmicNetworkUpdate,
 		Delete: resourceCosmicNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_network_acl.go
+++ b/cosmic/resource_cosmic_network_acl.go
@@ -14,6 +14,9 @@ func resourceCosmicNetworkACL() *schema.Resource {
 		Create: resourceCosmicNetworkACLCreate,
 		Read:   resourceCosmicNetworkACLRead,
 		Delete: resourceCosmicNetworkACLDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_network_acl_rule.go
+++ b/cosmic/resource_cosmic_network_acl_rule.go
@@ -19,6 +19,9 @@ func resourceCosmicNetworkACLRule() *schema.Resource {
 		Read:   resourceCosmicNetworkACLRuleRead,
 		Update: resourceCosmicNetworkACLRuleUpdate,
 		Delete: resourceCosmicNetworkACLRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"acl_id": &schema.Schema{

--- a/cosmic/resource_cosmic_nic.go
+++ b/cosmic/resource_cosmic_nic.go
@@ -14,6 +14,9 @@ func resourceCosmicNIC() *schema.Resource {
 		Create: resourceCosmicNICCreate,
 		Read:   resourceCosmicNICRead,
 		Delete: resourceCosmicNICDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"network_id": &schema.Schema{

--- a/cosmic/resource_cosmic_port_forward.go
+++ b/cosmic/resource_cosmic_port_forward.go
@@ -19,6 +19,9 @@ func resourceCosmicPortForward() *schema.Resource {
 		Read:   resourceCosmicPortForwardRead,
 		Update: resourceCosmicPortForwardUpdate,
 		Delete: resourceCosmicPortForwardDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cosmic/resource_cosmic_private_gateway.go
+++ b/cosmic/resource_cosmic_private_gateway.go
@@ -14,6 +14,9 @@ func resourceCosmicPrivateGateway() *schema.Resource {
 		Create: resourceCosmicPrivateGatewayCreate,
 		Read:   resourceCosmicPrivateGatewayRead,
 		Delete: resourceCosmicPrivateGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address": &schema.Schema{

--- a/cosmic/resource_cosmic_secondary_ipaddress.go
+++ b/cosmic/resource_cosmic_secondary_ipaddress.go
@@ -14,6 +14,9 @@ func resourceCosmicSecondaryIPAddress() *schema.Resource {
 		Create: resourceCosmicSecondaryIPAddressCreate,
 		Read:   resourceCosmicSecondaryIPAddressRead,
 		Delete: resourceCosmicSecondaryIPAddressDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address": &schema.Schema{

--- a/cosmic/resource_cosmic_ssh_keypair.go
+++ b/cosmic/resource_cosmic_ssh_keypair.go
@@ -14,6 +14,9 @@ func resourceCosmicSSHKeyPair() *schema.Resource {
 		Create: resourceCosmicSSHKeyPairCreate,
 		Read:   resourceCosmicSSHKeyPairRead,
 		Delete: resourceCosmicSSHKeyPairDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_static_nat.go
+++ b/cosmic/resource_cosmic_static_nat.go
@@ -15,6 +15,9 @@ func resourceCosmicStaticNAT() *schema.Resource {
 		Exists: resourceCosmicStaticNATExists,
 		Read:   resourceCosmicStaticNATRead,
 		Delete: resourceCosmicStaticNATDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ip_address_id": &schema.Schema{

--- a/cosmic/resource_cosmic_static_route.go
+++ b/cosmic/resource_cosmic_static_route.go
@@ -14,6 +14,9 @@ func resourceCosmicStaticRoute() *schema.Resource {
 		Create: resourceCosmicStaticRouteCreate,
 		Read:   resourceCosmicStaticRouteRead,
 		Delete: resourceCosmicStaticRouteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cidr": &schema.Schema{

--- a/cosmic/resource_cosmic_template.go
+++ b/cosmic/resource_cosmic_template.go
@@ -16,6 +16,9 @@ func resourceCosmicTemplate() *schema.Resource {
 		Read:   resourceCosmicTemplateRead,
 		Update: resourceCosmicTemplateUpdate,
 		Delete: resourceCosmicTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_vpn_connection.go
+++ b/cosmic/resource_cosmic_vpn_connection.go
@@ -14,6 +14,9 @@ func resourceCosmicVPNConnection() *schema.Resource {
 		Create: resourceCosmicVPNConnectionCreate,
 		Read:   resourceCosmicVPNConnectionRead,
 		Delete: resourceCosmicVPNConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"customer_gateway_id": &schema.Schema{

--- a/cosmic/resource_cosmic_vpn_customer_gateway.go
+++ b/cosmic/resource_cosmic_vpn_customer_gateway.go
@@ -15,6 +15,9 @@ func resourceCosmicVPNCustomerGateway() *schema.Resource {
 		Read:   resourceCosmicVPNCustomerGatewayRead,
 		Update: resourceCosmicVPNCustomerGatewayUpdate,
 		Delete: resourceCosmicVPNCustomerGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/cosmic/resource_cosmic_vpn_gateway.go
+++ b/cosmic/resource_cosmic_vpn_gateway.go
@@ -14,6 +14,9 @@ func resourceCosmicVPNGateway() *schema.Resource {
 		Create: resourceCosmicVPNGatewayCreate,
 		Read:   resourceCosmicVPNGatewayRead,
 		Delete: resourceCosmicVPNGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"vpc_id": &schema.Schema{


### PR DESCRIPTION
Importers allow you to bring existing resources under terraform control
and imports the resource info to the state. This commit adds support for
the `import` command to all resources.

Tested the most common ones manually, if problems come up with others
will fix then.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>