### PR TITLE
Make disk_offering a required param

### DIFF
--- a/cosmic/resource_cosmic_disk.go
+++ b/cosmic/resource_cosmic_disk.go
@@ -22,6 +22,11 @@ func resourceCosmicDisk() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"disk_offering": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
 			"attach": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -32,11 +37,6 @@ func resourceCosmicDisk() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-			},
-
-			"disk_offering": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
 			},
 
 			"size": &schema.Schema{


### PR DESCRIPTION
Without specifying the `disk_offering` param the `cosmic_disk` resource will fail to create a new Cosmic storage resource.

This PR makes it a required param.