### PR TITLE
Prevent recreating resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Changing `cosmic_network`'s `ip_exclusion_list` option no longer recreates the resource
+- Changing `cosmic_vpc`'s `vpc_offering` option no longer recreates the resource
+
 ## 0.1.0 (2019-01-27)
 
 First versioned release.

--- a/cosmic/resource_cosmic_network.go
+++ b/cosmic/resource_cosmic_network.go
@@ -108,7 +108,6 @@ func resourceCosmicNetwork() *schema.Resource {
 			"ip_exclusion_list": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"project": &schema.Schema{

--- a/cosmic/resource_cosmic_vpc.go
+++ b/cosmic/resource_cosmic_vpc.go
@@ -40,7 +40,6 @@ func resourceCosmicVPC() *schema.Resource {
 			"vpc_offering": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"network_domain": &schema.Schema{
@@ -248,6 +247,17 @@ func resourceCosmicVPCUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Set the new display text
 		p.SetSyslogserverlist(syslogserverlist.(string))
+	}
+
+	// Check if the VPC offering is changed
+	if d.HasChange("vpc_offering") {
+		// Retrieve the VPC offering ID
+		o, _, err := cs.VPC.GetVPCOfferingByName(d.Get("vpc_offering").(string))
+		if err != nil {
+			return err
+		}
+		// Set the new VPC offering ID
+		p.SetVpcofferingid(o.Id)
 	}
 
 	// Update the VPC


### PR DESCRIPTION
These resource options can be updated in-place via the API and no longer require recreating the source.