### PR TITLE
Add COSMIC_CONFIG and COSMIC_PROFILE env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Add option to configure provider using `COSMIC_CONFIG` and `COSMIC_PROFILE` environment variables
+
 ## 0.1.0 (2019-01-27)
 
 First versioned release.

--- a/cosmic/provider.go
+++ b/cosmic/provider.go
@@ -1,10 +1,11 @@
 package cosmic
 
 import (
+	"errors"
+
+	"github.com/go-ini/ini"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"errors"
-	"github.com/go-ini/ini"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -47,12 +48,14 @@ func Provider() terraform.ResourceProvider {
 			"config": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("COSMIC_CONFIG", nil),
 				ConflictsWith: []string{"api_url", "api_key", "secret_key"},
 			},
 
 			"profile": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("COSMIC_PROFILE", nil),
 				ConflictsWith: []string{"api_url", "api_key", "secret_key"},
 			},
 		},


### PR DESCRIPTION
Allow provider `config` and `profile` options to be configured using env vars.
