### PR TITLE
Add protocol number support to cosmic_network_acl_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## Unreleased
 
 - Add option to configure provider using `COSMIC_CONFIG` and `COSMIC_PROFILE` environment variables
+- Add ability to use protocol numbers for `cosmic_network_acl_rule`'s `protocol` option (instead of only `icmp`, `tcp`, `udp`, `all`)
 - Changing `cosmic_loadbalancer_rule`'s `member_ids`, `private_port`, `public_port` or `protocol` options no longer recreates the resource
 - Changing `cosmic_network`'s `ip_exclusion_list` option no longer recreates the resource
 - Changing `cosmic_vpc`'s `vpc_offering` option no longer recreates the resource

--- a/cosmic/resource_cosmic_network_acl_rule_test.go
+++ b/cosmic/resource_cosmic_network_acl_rule_test.go
@@ -21,22 +21,6 @@ func TestAccCosmicNetworkACLRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCosmicNetworkACLRulesExist("cosmic_network_acl.foo"),
 					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.#", "3"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.action", "allow"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.2835005819", "172.16.100.0/24"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.protocol", "tcp"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.#", "2"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.1889509032", "80"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.3638101695", "443"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.traffic_type", "ingress"),
-					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.action", "allow"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.cidr_list.#", "1"),
@@ -47,7 +31,51 @@ func TestAccCosmicNetworkACLRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.icmp_type", "-1"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1480917538.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1480917538.protocol", "icmp"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.2835005819", "172.16.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.#", "2"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.1889509032", "80"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.3638101695", "443"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.protocol", "all"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.protocol", "47"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.traffic_type", "ingress"),
 				),
 			},
 		},
@@ -65,22 +93,6 @@ func TestAccCosmicNetworkACLRule_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCosmicNetworkACLRulesExist("cosmic_network_acl.foo"),
 					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.#", "3"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.action", "allow"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.2835005819", "172.16.100.0/24"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.protocol", "tcp"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.#", "2"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.1889509032", "80"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.3638101695", "443"),
-					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2898748868.traffic_type", "ingress"),
-					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.action", "allow"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.cidr_list.#", "1"),
@@ -91,7 +103,51 @@ func TestAccCosmicNetworkACLRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.icmp_type", "-1"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1480917538.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1480917538.protocol", "icmp"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1480917538.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.cidr_list.2835005819", "172.16.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.#", "2"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.1889509032", "80"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.ports.3638101695", "443"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2898748868.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.protocol", "all"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3943933455.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.protocol", "47"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.865820176.traffic_type", "ingress"),
 				),
 			},
 
@@ -100,19 +156,25 @@ func TestAccCosmicNetworkACLRule_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCosmicNetworkACLRulesExist("cosmic_network_acl.foo"),
 					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.#", "4"),
+						"cosmic_network_acl_rule.foo", "rule.#", "5"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.action", "deny"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1724235854.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.cidr_list.3482919157", "10.0.0.0/24"),
 					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.1724235854.protocol", "tcp"),
+						"cosmic_network_acl_rule.foo", "rule.1724235854.icmp_code", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1724235854.icmp_type", "0"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.ports.#", "2"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.ports.1209010669", "1000-2000"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.ports.1889509032", "80"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.1724235854.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.1724235854.traffic_type", "egress"),
 					resource.TestCheckResourceAttr(
@@ -128,13 +190,37 @@ func TestAccCosmicNetworkACLRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2090315355.icmp_type", "-1"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2090315355.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2090315355.protocol", "icmp"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2090315355.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.action", "deny"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.icmp_code", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.icmp_type", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.protocol", "47"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2548582181.traffic_type", "ingress"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2576683033.action", "allow"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2576683033.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2576683033.cidr_list.3056857544", "172.18.100.0/24"),
 					resource.TestCheckResourceAttr(
-						"cosmic_network_acl_rule.foo", "rule.2576683033.protocol", "tcp"),
+						"cosmic_network_acl_rule.foo", "rule.2576683033.icmp_code", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2576683033.icmp_type", "0"),
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2576683033.ports.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -142,7 +228,25 @@ func TestAccCosmicNetworkACLRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2576683033.ports.3638101695", "443"),
 					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.2576683033.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
 						"cosmic_network_acl_rule.foo", "rule.2576683033.traffic_type", "ingress"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.action", "deny"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.cidr_list.#", "1"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.cidr_list.3056857544", "172.18.100.0/24"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.icmp_code", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.icmp_type", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.ports.#", "0"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.protocol", "all"),
+					resource.TestCheckResourceAttr(
+						"cosmic_network_acl_rule.foo", "rule.3171160373.traffic_type", "ingress"),
 				),
 			},
 		},
@@ -235,6 +339,13 @@ resource "cosmic_network_acl_rule" "foo" {
   }
 
   rule {
+    action       = "allow"
+    cidr_list    = ["172.18.100.0/24"]
+    protocol     = "47"
+    traffic_type = "ingress"
+  }
+
+  rule {
     cidr_list    = ["172.16.100.0/24"]
     protocol     = "tcp"
     ports        = ["80", "443"]
@@ -265,6 +376,13 @@ resource "cosmic_network_acl_rule" "foo" {
     protocol     = "icmp"
     icmp_type    = "-1"
     icmp_code    = "-1"
+    traffic_type = "ingress"
+  }
+
+  rule {
+    action       = "deny"
+    cidr_list    = ["172.18.100.0/24"]
+    protocol     = "47"
     traffic_type = "ingress"
   }
 


### PR DESCRIPTION
This PRs allow specifying the protocol number, e.g.

```
rule {
  action       = "allow"
  cidr_list    = ["0.0.0.0/0"]
  protocol     = "47"
  traffic_type = "ingress"
}
```

Before this was silently skipped.