### PR TITLE
Make acc testing variables optional

### DIFF
--- a/cosmic/provider_test.go
+++ b/cosmic/provider_test.go
@@ -60,38 +60,10 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("COSMIC_SECRET_KEY"); v == "" {
 		t.Fatal("COSMIC_SECRET_KEY must be set for acceptance tests")
 	}
-	if v := os.Getenv("COSMIC_DISK_OFFERING_1"); v == "" {
-		t.Fatal("COSMIC_DISK_OFFERING_1 must be set for acceptance tests")
 	}
-	if v := os.Getenv("COSMIC_DISK_OFFERING_2"); v == "" {
-		t.Fatal("COSMIC_DISK_OFFERING_2 must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_SERVICE_OFFERING_1"); v == "" {
-		t.Fatal("COSMIC_SERVICE_OFFERING_1 must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_SERVICE_OFFERING_2"); v == "" {
-		t.Fatal("COSMIC_SERVICE_OFFERING_2 must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_VPC_ID"); v == "" {
-		t.Fatal("COSMIC_VPC_ID must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_VPC_OFFERING"); v == "" {
-		t.Fatal("COSMIC_VPC_OFFERING must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_VPC_NETWORK_OFFERING"); v == "" {
-		t.Fatal("COSMIC_VPC_NETWORK_OFFERING must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_TEMPLATE"); v == "" {
-		t.Fatal("COSMIC_TEMPLATE must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_PROJECT_NAME"); v == "" {
-		t.Fatal("COSMIC_PROJECT_NAME must be set for acceptance tests")
 	}
 	if v := os.Getenv("COSMIC_ZONE"); v == "" {
 		t.Fatal("COSMIC_ZONE must be set for acceptance tests")
-	}
-	if v := os.Getenv("COSMIC_DEFAULT_ALLOW_ACL_ID"); v == "" {
-		t.Fatal("COSMIC_DEFAULT_ALLOW_ACL_ID must be set for acceptance tests")
 	}
 }
 

--- a/cosmic/resource_cosmic_disk_test.go
+++ b/cosmic/resource_cosmic_disk_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicDisk_basic(t *testing.T) {
+	if COSMIC_DISK_OFFERING_1 == "" {
+		t.Skip("This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)")
+	}
+
 	var disk cosmic.Volume
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +34,10 @@ func TestAccCosmicDisk_basic(t *testing.T) {
 }
 
 func TestAccCosmicDisk_update(t *testing.T) {
+	if COSMIC_DISK_OFFERING_1 == "" {
+		t.Skip("This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)")
+	}
+
 	var disk cosmic.Volume
 
 	resource.Test(t, resource.TestCase{
@@ -62,6 +70,26 @@ func TestAccCosmicDisk_update(t *testing.T) {
 }
 
 func TestAccCosmicDisk_attachBasic(t *testing.T) {
+	if COSMIC_DISK_OFFERING_1 == "" {
+		t.Skip("This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var disk cosmic.Volume
 
 	resource.Test(t, resource.TestCase{
@@ -82,6 +110,22 @@ func TestAccCosmicDisk_attachBasic(t *testing.T) {
 }
 
 func TestAccCosmicDisk_attachUpdate(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var disk cosmic.Volume
 
 	resource.Test(t, resource.TestCase{
@@ -114,6 +158,22 @@ func TestAccCosmicDisk_attachUpdate(t *testing.T) {
 }
 
 func TestAccCosmicDisk_attachDeviceID(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var disk cosmic.Volume
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_instance_test.go
+++ b/cosmic/resource_cosmic_instance_test.go
@@ -10,6 +10,26 @@ import (
 )
 
 func TestAccCosmicInstance_basic(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_2 == "" {
+		t.Skip("This test requires a second existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_2)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var instance cosmic.VirtualMachine
 
 	resource.Test(t, resource.TestCase{
@@ -32,6 +52,26 @@ func TestAccCosmicInstance_basic(t *testing.T) {
 }
 
 func TestAccCosmicInstance_update(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_2 == "" {
+		t.Skip("This test requires a second existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_2)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var instance cosmic.VirtualMachine
 
 	resource.Test(t, resource.TestCase{
@@ -69,6 +109,26 @@ func TestAccCosmicInstance_update(t *testing.T) {
 }
 
 func TestAccCosmicInstance_fixedIP(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_2 == "" {
+		t.Skip("This test requires a second existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_2)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var instance cosmic.VirtualMachine
 
 	resource.Test(t, resource.TestCase{
@@ -90,6 +150,26 @@ func TestAccCosmicInstance_fixedIP(t *testing.T) {
 }
 
 func TestAccCosmicInstance_keyPair(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_2 == "" {
+		t.Skip("This test requires a second existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_2)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var instance cosmic.VirtualMachine
 
 	resource.Test(t, resource.TestCase{
@@ -111,6 +191,30 @@ func TestAccCosmicInstance_keyPair(t *testing.T) {
 }
 
 func TestAccCosmicInstance_project(t *testing.T) {
+	if COSMIC_PROJECT_NAME == "" {
+		t.Skip("This test requires an existing project (set it by exporting COSMIC_PROJECT_NAME)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_2 == "" {
+		t.Skip("This test requires a second existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_2)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var instance cosmic.VirtualMachine
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_ipaddress_test.go
+++ b/cosmic/resource_cosmic_ipaddress_test.go
@@ -10,6 +10,14 @@ import (
 )
 
 func TestAccCosmicIPAddress_basic(t *testing.T) {
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var ipaddr cosmic.PublicIpAddress
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_loadbalancer_rule_test.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule_test.go
@@ -11,6 +11,26 @@ import (
 )
 
 func TestAccCosmicLoadBalancerRule_basic(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -35,6 +55,26 @@ func TestAccCosmicLoadBalancerRule_basic(t *testing.T) {
 }
 
 func TestAccCosmicLoadBalancerRule_update(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var id string
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_network_acl_rule_test.go
+++ b/cosmic/resource_cosmic_network_acl_rule_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccCosmicNetworkACLRule_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -55,6 +59,10 @@ func TestAccCosmicNetworkACLRule_basic(t *testing.T) {
 }
 
 func TestAccCosmicNetworkACLRule_update(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/cosmic/resource_cosmic_network_acl_test.go
+++ b/cosmic/resource_cosmic_network_acl_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicNetworkACL_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var acl cosmic.NetworkACLList
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/cosmic/resource_cosmic_network_test.go
+++ b/cosmic/resource_cosmic_network_test.go
@@ -10,6 +10,14 @@ import (
 )
 
 func TestAccCosmicNetwork_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var network cosmic.Network
 
 	resource.Test(t, resource.TestCase{
@@ -31,6 +39,14 @@ func TestAccCosmicNetwork_basic(t *testing.T) {
 }
 
 func TestAccCosmicNetwork_updateACL(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var network cosmic.Network
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_nic_test.go
+++ b/cosmic/resource_cosmic_nic_test.go
@@ -10,6 +10,22 @@ import (
 )
 
 func TestAccCosmicNIC_basic(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var nic cosmic.Nic
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +46,22 @@ func TestAccCosmicNIC_basic(t *testing.T) {
 }
 
 func TestAccCosmicNIC_update(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var nic cosmic.Nic
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_port_forward_test.go
+++ b/cosmic/resource_cosmic_port_forward_test.go
@@ -11,6 +11,26 @@ import (
 )
 
 func TestAccCosmicPortForward_basic(t *testing.T) {
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -29,6 +49,26 @@ func TestAccCosmicPortForward_basic(t *testing.T) {
 }
 
 func TestAccCosmicPortForward_update(t *testing.T) {
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/cosmic/resource_cosmic_private_gateway_test.go
+++ b/cosmic/resource_cosmic_private_gateway_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicPrivateGateway_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var gateway cosmic.PrivateGateway
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_secondary_ipaddress_test.go
+++ b/cosmic/resource_cosmic_secondary_ipaddress_test.go
@@ -10,6 +10,22 @@ import (
 )
 
 func TestAccCosmicSecondaryIPAddress_basic(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var ip cosmic.AddIpToNicResponse
 
 	resource.Test(t, resource.TestCase{
@@ -29,6 +45,22 @@ func TestAccCosmicSecondaryIPAddress_basic(t *testing.T) {
 }
 
 func TestAccCosmicSecondaryIPAddress_fixedIP(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var ip cosmic.AddIpToNicResponse
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_static_nat_test.go
+++ b/cosmic/resource_cosmic_static_nat_test.go
@@ -10,6 +10,26 @@ import (
 )
 
 func TestAccCosmicStaticNAT_basic(t *testing.T) {
+	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
+		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
+	}
+
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
 	var ipaddr cosmic.PublicIpAddress
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_static_route_test.go
+++ b/cosmic/resource_cosmic_static_route_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicStaticRoute_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var route cosmic.StaticRoute
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_vpc_test.go
+++ b/cosmic/resource_cosmic_vpc_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicVPC_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var vpc cosmic.VPC
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_vpn_connection_test.go
+++ b/cosmic/resource_cosmic_vpn_connection_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicVPNConnection_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var vpnConnection cosmic.VpnConnection
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_vpn_customer_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_customer_gateway_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicVPNCustomerGateway_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var vpnCustomerGateway cosmic.VpnCustomerGateway
 
 	resource.Test(t, resource.TestCase{

--- a/cosmic/resource_cosmic_vpn_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_gateway_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccCosmicVPNGateway_basic(t *testing.T) {
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
 	var vpnGateway cosmic.VpnGateway
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
As it is currently running individual tests requires all test variables to be set (e.g. required to export  `COSMIC_DISK_OFFERING` variable to test static routes).

This PR makes the provider variables required (`COSMIC_API_URL`,`COSMIC_API_KEY`, `COSMIC_SECRET_KEY` and `COSMIC_ZONE`) and the rest optional.  

```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccCosmicAffinityGroup_basic
--- PASS: TestAccCosmicAffinityGroup_basic (0.64s)
=== RUN   TestAccCosmicDisk_basic
--- SKIP: TestAccCosmicDisk_basic (0.00s)
	resource_cosmic_disk_test.go:14: This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)
=== RUN   TestAccCosmicDisk_update
--- SKIP: TestAccCosmicDisk_update (0.00s)
	resource_cosmic_disk_test.go:38: This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)
=== RUN   TestAccCosmicDisk_attachBasic
--- SKIP: TestAccCosmicDisk_attachBasic (0.00s)
	resource_cosmic_disk_test.go:74: This test requires an existing disk offering (set it by exporting COSMIC_DISK_OFFERING_1)
=== RUN   TestAccCosmicDisk_attachUpdate
--- SKIP: TestAccCosmicDisk_attachUpdate (0.00s)
	resource_cosmic_disk_test.go:114: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicDisk_attachDeviceID
--- SKIP: TestAccCosmicDisk_attachDeviceID (0.00s)
	resource_cosmic_disk_test.go:162: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicInstance_basic
--- SKIP: TestAccCosmicInstance_basic (0.00s)
	resource_cosmic_instance_test.go:14: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicInstance_update
--- SKIP: TestAccCosmicInstance_update (0.00s)
	resource_cosmic_instance_test.go:56: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicInstance_fixedIP
--- SKIP: TestAccCosmicInstance_fixedIP (0.00s)
	resource_cosmic_instance_test.go:113: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicInstance_keyPair
--- SKIP: TestAccCosmicInstance_keyPair (0.00s)
	resource_cosmic_instance_test.go:154: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicInstance_project
--- SKIP: TestAccCosmicInstance_project (0.00s)
	resource_cosmic_instance_test.go:195: This test requires an existing project (set it by exporting COSMIC_PROJECT_NAME)
=== RUN   TestAccCosmicIPAddress_basic
--- SKIP: TestAccCosmicIPAddress_basic (0.00s)
	resource_cosmic_ipaddress_test.go:14: This test requires a "default_allow" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)
=== RUN   TestAccCosmicLoadBalancerRule_basic
--- SKIP: TestAccCosmicLoadBalancerRule_basic (0.00s)
	resource_cosmic_loadbalancer_rule_test.go:15: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicLoadBalancerRule_update
--- SKIP: TestAccCosmicLoadBalancerRule_update (0.00s)
	resource_cosmic_loadbalancer_rule_test.go:59: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicNetworkACLRule_basic
--- SKIP: TestAccCosmicNetworkACLRule_basic (0.00s)
	resource_cosmic_network_acl_rule_test.go:15: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicNetworkACLRule_update
--- SKIP: TestAccCosmicNetworkACLRule_update (0.00s)
	resource_cosmic_network_acl_rule_test.go:63: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicNetworkACL_basic
--- SKIP: TestAccCosmicNetworkACL_basic (0.00s)
	resource_cosmic_network_acl_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicNetwork_basic
--- SKIP: TestAccCosmicNetwork_basic (0.00s)
	resource_cosmic_network_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicNetwork_updateACL
--- SKIP: TestAccCosmicNetwork_updateACL (0.00s)
	resource_cosmic_network_test.go:43: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicNIC_basic
--- SKIP: TestAccCosmicNIC_basic (0.00s)
	resource_cosmic_nic_test.go:14: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicNIC_update
--- SKIP: TestAccCosmicNIC_update (0.00s)
	resource_cosmic_nic_test.go:50: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicPortForward_basic
--- SKIP: TestAccCosmicPortForward_basic (0.00s)
	resource_cosmic_port_forward_test.go:15: This test requires a "default_allow" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)
=== RUN   TestAccCosmicPortForward_update
--- SKIP: TestAccCosmicPortForward_update (0.00s)
	resource_cosmic_port_forward_test.go:53: This test requires a "default_allow" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)
=== RUN   TestAccCosmicPrivateGateway_basic
--- SKIP: TestAccCosmicPrivateGateway_basic (0.00s)
	resource_cosmic_private_gateway_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicSecondaryIPAddress_basic
--- SKIP: TestAccCosmicSecondaryIPAddress_basic (0.00s)
	resource_cosmic_secondary_ipaddress_test.go:14: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicSecondaryIPAddress_fixedIP
--- SKIP: TestAccCosmicSecondaryIPAddress_fixedIP (0.00s)
	resource_cosmic_secondary_ipaddress_test.go:49: This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)
=== RUN   TestAccCosmicSSHKeyPair_basic
--- PASS: TestAccCosmicSSHKeyPair_basic (0.51s)
=== RUN   TestAccCosmicSSHKeyPair_register
--- PASS: TestAccCosmicSSHKeyPair_register (0.25s)
=== RUN   TestAccCosmicStaticNAT_basic
--- SKIP: TestAccCosmicStaticNAT_basic (0.00s)
	resource_cosmic_static_nat_test.go:14: This test requires a "default_allow" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)
=== RUN   TestAccCosmicStaticRoute_basic
--- SKIP: TestAccCosmicStaticRoute_basic (0.00s)
	resource_cosmic_static_route_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicTemplate_basic
--- PASS: TestAccCosmicTemplate_basic (104.12s)
=== RUN   TestAccCosmicTemplate_update
--- PASS: TestAccCosmicTemplate_update (104.39s)
=== RUN   TestAccCosmicVPC_basic
--- SKIP: TestAccCosmicVPC_basic (0.00s)
	resource_cosmic_vpc_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicVPNConnection_basic
--- SKIP: TestAccCosmicVPNConnection_basic (0.00s)
	resource_cosmic_vpn_connection_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicVPNCustomerGateway_basic
--- SKIP: TestAccCosmicVPNCustomerGateway_basic (0.00s)
	resource_cosmic_vpn_customer_gateway_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestAccCosmicVPNGateway_basic
--- SKIP: TestAccCosmicVPNGateway_basic (0.00s)
	resource_cosmic_vpn_gateway_test.go:14: This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)
=== RUN   TestDiffTags
--- PASS: TestDiffTags (0.00s)
PASS
ok  	github.com/MissionCriticalCloud/terraform-provider-cosmic/cosmic	209.962s
```

Signed-off-by: Stephen Hoekstra <stephenhoekstra@gmail.com>