### PR TITLE
Feature/add diskcontroller parameter on disk resource

### DIFF
--- a/cosmic/provider_test.go
+++ b/cosmic/provider_test.go
@@ -80,6 +80,9 @@ var COSMIC_SERVICE_OFFERING_2 = os.Getenv("COSMIC_SERVICE_OFFERING_2")
 // ID of an existing VPC
 var COSMIC_VPC_ID = os.Getenv("COSMIC_VPC_ID")
 
+// ID of an existing VPC network
+var COSMIC_VPC_NETWORK_ID = os.Getenv("COSMIC_VPC_NETWORK_ID")
+
 // An available VPC offering
 var COSMIC_VPC_OFFERING = os.Getenv("COSMIC_VPC_OFFERING")
 

--- a/cosmic/resource_cosmic_disk.go
+++ b/cosmic/resource_cosmic_disk.go
@@ -59,6 +59,16 @@ func resourceCosmicDisk() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					switch v {
+					case "IDE", "SCSI", "VIRTIO":
+					default:
+						errs = append(errs, fmt.Errorf("%q must be either 'IDE', 'SCSI' or 'VIRTIO', got: %q", key, v))
+					}
+
+					return
+				},
 			},
 
 			"virtual_machine_id": &schema.Schema{
@@ -106,11 +116,8 @@ func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Set the disk_controller type if configured
-	if diskcontroller := strings.ToUpper(d.Get("disk_controller").(string)); diskcontroller != "" {
-
-		if diskcontroller == "IDE" || diskcontroller == "SCSI" || diskcontroller == "VIRTIO" {
-			p.SetDiskcontroller(diskcontroller)
-		}
+	if diskcontroller, ok := d.GetOk("disk_controller"); ok {
+		p.SetDiskcontroller(diskcontroller.(string))
 	}
 
 	// If there is a project supplied, we retrieve and set the project id

--- a/cosmic/resource_cosmic_disk_test.go
+++ b/cosmic/resource_cosmic_disk_test.go
@@ -86,8 +86,8 @@ func TestAccCosmicDisk_attachBasic(t *testing.T) {
 		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
 	}
 
-	if COSMIC_VPC_NETWORK_OFFERING == "" {
-		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	if COSMIC_VPC_NETWORK_ID == "" {
+		t.Skip("This test requires an existing VPC network ID (set it by exporting COSMIC_VPC_NETWORK_ID)")
 	}
 
 	var disk cosmic.Volume
@@ -122,8 +122,8 @@ func TestAccCosmicDisk_attachUpdate(t *testing.T) {
 		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
 	}
 
-	if COSMIC_VPC_NETWORK_OFFERING == "" {
-		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	if COSMIC_VPC_NETWORK_ID == "" {
+		t.Skip("This test requires an existing VPC network ID (set it by exporting COSMIC_VPC_NETWORK_ID)")
 	}
 
 	var disk cosmic.Volume
@@ -170,8 +170,8 @@ func TestAccCosmicDisk_attachDeviceID(t *testing.T) {
 		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
 	}
 
-	if COSMIC_VPC_NETWORK_OFFERING == "" {
-		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	if COSMIC_VPC_NETWORK_ID == "" {
+		t.Skip("This test requires an existing VPC network ID (set it by exporting COSMIC_VPC_NETWORK_ID)")
 	}
 
 	var disk cosmic.Volume
@@ -209,6 +209,8 @@ func TestAccCosmicDisk_diskController(t *testing.T) {
 					testAccCheckCosmicDiskExists(
 						"cosmic_disk.foo", &disk),
 					testAccCheckCosmicDiskAttributes(&disk),
+					resource.TestCheckResourceAttr(
+						"cosmic_disk.foo", "disk_controller", "SCSI"),
 				),
 			},
 		},
@@ -229,6 +231,8 @@ func TestAccCosmicDisk_attachDiskController(t *testing.T) {
 					testAccCheckCosmicDiskExists(
 						"cosmic_disk.foo", &disk),
 					testAccCheckCosmicDiskAttributes(&disk),
+					resource.TestCheckResourceAttr(
+						"cosmic_disk.foo", "disk_controller", "SCSI"),
 				),
 			},
 		},
@@ -336,22 +340,13 @@ resource "cosmic_disk" "foo" {
 	COSMIC_ZONE)
 
 var testAccCosmicDisk_attachBasic = fmt.Sprintf(`
-resource "cosmic_network" "foo" {
-  name             = "terraform-network"
-  cidr             = "10.0.10.0/24"
-  gateway          = "10.0.10.1"
-  network_offering = "%s"
-  vpc_id           = "%s"
-  zone             = "%s"
-}
-
 resource "cosmic_instance" "foo" {
   name             = "terraform-test"
   display_name     = "terraform"
   service_offering = "%s"
-  network_id       = "${cosmic_network.foo.id}"
+  network_id       = "%s"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
+  zone             = "%s"
   expunge          = true
 }
 
@@ -363,30 +358,20 @@ resource "cosmic_disk" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
   zone               = "${cosmic_instance.foo.zone}"
 }`,
-	COSMIC_VPC_NETWORK_OFFERING,
-	COSMIC_VPC_ID,
-	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
+	COSMIC_VPC_NETWORK_ID,
 	COSMIC_TEMPLATE,
+	COSMIC_ZONE,
 	COSMIC_DISK_OFFERING_1)
 
 var testAccCosmicDisk_attachDiskController = fmt.Sprintf(`
-resource "cosmic_network" "foo" {
-  name             = "terraform-network"
-  cidr             = "10.0.10.0/24"
-  gateway          = "10.0.10.1"
-  network_offering = "%s"
-  vpc_id           = "%s"
-  zone             = "%s"
-}
-
 resource "cosmic_instance" "foo" {
   name             = "terraform-test"
   display_name     = "terraform"
   service_offering = "%s"
-  network_id       = "${cosmic_network.foo.id}"
+  network_id       = "%s"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
+  zone             = "%s"
   expunge          = true
 }
 
@@ -399,30 +384,20 @@ resource "cosmic_disk" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
   zone               = "${cosmic_instance.foo.zone}"
 }`,
-	COSMIC_VPC_NETWORK_OFFERING,
-	COSMIC_VPC_ID,
-	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
+	COSMIC_VPC_NETWORK_ID,
 	COSMIC_TEMPLATE,
+	COSMIC_ZONE,
 	COSMIC_DISK_OFFERING_1)
 
 var testAccCosmicDisk_attachDeviceID = fmt.Sprintf(`
-resource "cosmic_network" "foo" {
-  name             = "terraform-network"
-  cidr             = "10.0.10.0/24"
-  gateway          = "10.0.10.1"
-  network_offering = "%s"
-  vpc_id           = "%s"
-  zone             = "%s"
-}
-
 resource "cosmic_instance" "foo" {
   name             = "terraform-test"
   display_name     = "terraform"
   service_offering = "%s"
-  network_id       = "${cosmic_network.foo.id}"
+  network_id       = "%s"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
+  zone             = "%s"
   expunge          = true
 }
 
@@ -435,30 +410,20 @@ resource "cosmic_disk" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
   zone               = "${cosmic_instance.foo.zone}"
 }`,
-	COSMIC_VPC_NETWORK_OFFERING,
-	COSMIC_VPC_ID,
-	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
+	COSMIC_VPC_NETWORK_ID,
 	COSMIC_TEMPLATE,
+	COSMIC_ZONE,
 	COSMIC_DISK_OFFERING_1)
 
 var testAccCosmicDisk_attachUpdate = fmt.Sprintf(`
-resource "cosmic_network" "foo" {
-  name             = "terraform-network"
-  cidr             = "10.0.10.0/24"
-  gateway          = "10.0.10.1"
-  network_offering = "%s"
-  vpc_id           = "%s"
-  zone             = "%s"
-}
-
 resource "cosmic_instance" "foo" {
   name             = "terraform-test"
   display_name     = "terraform"
   service_offering = "%s"
-  network_id       = "${cosmic_network.foo.id}"
+  network_id       = "%s"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
+  zone             = "%s"
   expunge          = true
 }
 
@@ -470,9 +435,8 @@ resource "cosmic_disk" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
   zone               = "${cosmic_instance.foo.zone}"
 }`,
-	COSMIC_VPC_NETWORK_OFFERING,
-	COSMIC_VPC_ID,
-	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
+	COSMIC_VPC_NETWORK_ID,
 	COSMIC_TEMPLATE,
+	COSMIC_ZONE,
 	COSMIC_DISK_OFFERING_1)

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -19,6 +19,7 @@ resource "cosmic_disk" "default" {
   attach             = "true"
   disk_offering      = "custom"
   size               = 50
+  disk_controller    = "VIRTIO"
   virtual_machine_id = "server-1"
   zone               = "zone-1"
 }
@@ -43,6 +44,9 @@ The following arguments are supported:
 
 * `shrink_ok` - (Optional) Verifies if the disk volume is allowed to shrink when
     resizing (defaults false).
+
+* `disk_controller` - (Optional) Set the disk controller type for this disk. Allowed 
+     options are IDE, SCSI and VIRTIO. Changing this forces a new resource to be created.
 
 * `virtual_machine_id` - (Optional) The ID of the virtual machine to which you want
     to attach the disk volume.


### PR DESCRIPTION
Simple version, it will recreate a disk on diskcontroller change, if you need to change the diskcontroller, please update the disk manually, and afterwards, run apply to update the state.

It only works for the disk resource, not for the instance root disk.