### PR TITLE
Add `cosmic_network_acl` data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+- Add `cosmic_network_acl` data source to look up Network ACL Lists
 - Set `optimise_for` value when importing a Cosmic instance
 
 ## 0.3.1 (2019-08-06)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ $ make testacc
 
 Optionally the following need to be exported for certain tests:
 
-- `COSMIC_DEFAULT_ALLOW_ACL_ID` - UUID of the "default_allow" ACL
 - `COSMIC_DISK_OFFERING_1` -  An existing disk offering to test storage
 - `COSMIC_DISK_OFFERING_2` -  A second existing disk offering to test provisioning storage
 - `COSMIC_INSTANCE_ID` - An existing instance to test instance-related resources

--- a/cosmic/data_source_cosmic_common_schema.go
+++ b/cosmic/data_source_cosmic_common_schema.go
@@ -1,0 +1,55 @@
+package cosmic
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceFiltersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Required: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+// matchFilters returns true or false depending if the passed filters are matched.
+func matchFilters(v interface{}, filters *schema.Set) (bool, error) {
+	var j map[string]interface{}
+	t, _ := json.Marshal(v)
+	json.Unmarshal(t, &j)
+
+	for _, f := range filters.List() {
+		m := f.(map[string]interface{})
+
+		value, ok := j[m["name"].(string)].(string)
+		if !ok {
+			return false, fmt.Errorf("Invalid field name: %s", m["name"])
+		}
+
+		re, err := regexp.Compile(m["value"].(string))
+		if err != nil {
+			return false, fmt.Errorf("Invalid regex: %s", err)
+		}
+		if !re.MatchString(value) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/cosmic/data_source_cosmic_network_acl.go
+++ b/cosmic/data_source_cosmic_network_acl.go
@@ -1,0 +1,82 @@
+package cosmic
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCosmicNetworkACL() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCosmicNetworkACLRead,
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+
+			// Computed values
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCosmicNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*cosmic.CosmicClient)
+
+	p := conn.NetworkACL.NewListNetworkACLListsParams()
+	p.SetListall(true)
+
+	cosmicACLLists, err := conn.NetworkACL.ListNetworkACLLists(p)
+	if err != nil {
+		return fmt.Errorf("Failed to list ACL Lists: %s", err)
+	}
+
+	filters := d.Get("filter")
+	var ACLLists []*cosmic.NetworkACLList
+
+	for _, l := range cosmicACLLists.NetworkACLLists {
+		match, err := matchFilters(l, filters.(*schema.Set))
+		if err != nil {
+			return err
+		}
+
+		if match {
+			ACLLists = append(ACLLists, l)
+		}
+	}
+
+	if len(ACLLists) == 0 {
+		return fmt.Errorf("No Network ACL List matched with the specified filter")
+	}
+
+	if len(ACLLists) > 1 {
+		return fmt.Errorf("More than one Network ACL List found, use a more specific filter")
+	}
+
+	log.Printf("[DEBUG] Selected Network ACL List: %s\n", ACLLists[0].Id)
+
+	d.SetId(ACLLists[0].Id)
+	d.Set("name", ACLLists[0].Name)
+	d.Set("description", ACLLists[0].Description)
+	d.Set("vpc_id", ACLLists[0].Vpcid)
+
+	return nil
+}

--- a/cosmic/data_source_cosmic_network_acl_test.go
+++ b/cosmic/data_source_cosmic_network_acl_test.go
@@ -1,0 +1,89 @@
+package cosmic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceCosmicNetworkACL_basic(t *testing.T) {
+	var aclList cosmic.NetworkACLList
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCosmicNetworkACL_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCosmicNetworkACLDataSourceExists("data.cosmic_network_acl.default_allow", &aclList),
+					testAccCheckCosmicNetworkACLDataSourceAttributes(&aclList),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCosmicNetworkACLDataSourceExists(n string, aclList *cosmic.NetworkACLList) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Network ACL List data source ID not set")
+		}
+
+		conn := testAccProvider.Meta().(*cosmic.CosmicClient)
+		list, _, err := conn.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if list.Id != rs.Primary.ID {
+			return fmt.Errorf("Network ACL List not found")
+		}
+
+		*aclList = *list
+
+		return nil
+	}
+}
+
+func testAccCheckCosmicNetworkACLDataSourceAttributes(aclList *cosmic.NetworkACLList) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aclList.Name != "default_allow" {
+			return fmt.Errorf("Bad name: %s", aclList.Name)
+		}
+
+		if aclList.Description != "Default Network ACL Allow All" {
+			return fmt.Errorf("Bad description: %s", aclList.Description)
+		}
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "cosmic_network_acl" {
+				continue
+			}
+
+			if aclList.Id != rs.Primary.ID {
+				return fmt.Errorf("Bad Network ACL List ID: %s", aclList.Id)
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceCosmicNetworkACL_basic = `
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+`

--- a/cosmic/provider.go
+++ b/cosmic/provider.go
@@ -60,6 +60,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"cosmic_network_acl": dataSourceCosmicNetworkACL(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"cosmic_affinity_group":       resourceCosmicAffinityGroup(),
 			"cosmic_disk":                 resourceCosmicDisk(),

--- a/cosmic/provider_test.go
+++ b/cosmic/provider_test.go
@@ -97,6 +97,3 @@ var COSMIC_TEMPLATE = os.Getenv("COSMIC_TEMPLATE")
 
 // Name of a zone that exists already
 var COSMIC_ZONE = os.Getenv("COSMIC_ZONE")
-
-// ID of the "default_acl" built-in ACL
-var COSMIC_DEFAULT_ALLOW_ACL_ID = os.Getenv("COSMIC_DEFAULT_ALLOW_ACL_ID")

--- a/cosmic/resource_cosmic_ipaddress_test.go
+++ b/cosmic/resource_cosmic_ipaddress_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func TestAccCosmicIPAddress_basic(t *testing.T) {
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
-	}
-
 	if COSMIC_VPC_ID == "" {
 		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
 	}
@@ -106,9 +102,16 @@ func testAccCheckCosmicIPAddressDestroy(s *terraform.State) error {
 }
 
 var testAccCosmicIPAddress_basic = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "%s"
 }`,
-	COSMIC_DEFAULT_ALLOW_ACL_ID,
-	COSMIC_VPC_ID)
+	COSMIC_VPC_ID,
+)

--- a/cosmic/resource_cosmic_loadbalancer_rule_test.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule_test.go
@@ -19,10 +19,6 @@ func TestAccCosmicLoadBalancerRule_basic(t *testing.T) {
 		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
 	}
 
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
-	}
-
 	if COSMIC_VPC_ID == "" {
 		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
 	}
@@ -61,10 +57,6 @@ func TestAccCosmicLoadBalancerRule_update(t *testing.T) {
 
 	if COSMIC_TEMPLATE == "" {
 		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
-	}
-
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
 	}
 
 	if COSMIC_VPC_ID == "" {
@@ -177,6 +169,13 @@ func testAccCheckCosmicLoadBalancerRuleDestroy(s *terraform.State) error {
 }
 
 var testAccCosmicLoadBalancerRule_basic = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.10.0/24"
@@ -187,7 +186,7 @@ resource "cosmic_network" "foo" {
 }
 
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "${cosmic_network.foo.vpc_id}"
 }
 
@@ -213,11 +212,18 @@ resource "cosmic_loadbalancer_rule" "foo" {
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_VPC_ID,
 	COSMIC_ZONE,
-	COSMIC_DEFAULT_ALLOW_ACL_ID,
 	COSMIC_SERVICE_OFFERING_1,
-	COSMIC_TEMPLATE)
+	COSMIC_TEMPLATE,
+)
 
 var testAccCosmicLoadBalancerRule_update = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.10.0/24"
@@ -228,7 +234,7 @@ resource "cosmic_network" "foo" {
 }
 
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "${cosmic_network.foo.vpc_id}"
 }
 
@@ -264,6 +270,6 @@ resource "cosmic_loadbalancer_rule" "foo" {
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_VPC_ID,
 	COSMIC_ZONE,
-	COSMIC_DEFAULT_ALLOW_ACL_ID,
 	COSMIC_SERVICE_OFFERING_1,
-	COSMIC_TEMPLATE)
+	COSMIC_TEMPLATE,
+)

--- a/cosmic/resource_cosmic_port_forward_test.go
+++ b/cosmic/resource_cosmic_port_forward_test.go
@@ -11,10 +11,6 @@ import (
 )
 
 func TestAccCosmicPortForward_basic(t *testing.T) {
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
-	}
-
 	if COSMIC_SERVICE_OFFERING_1 == "" {
 		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
 	}
@@ -49,10 +45,6 @@ func TestAccCosmicPortForward_basic(t *testing.T) {
 }
 
 func TestAccCosmicPortForward_update(t *testing.T) {
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
-	}
-
 	if COSMIC_SERVICE_OFFERING_1 == "" {
 		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
 	}
@@ -155,6 +147,13 @@ func testAccCheckCosmicPortForwardDestroy(s *terraform.State) error {
 }
 
 var testAccCosmicPortForward_basic = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.10.0/24"
@@ -174,7 +173,7 @@ resource "cosmic_instance" "foo" {
 }
 
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "${cosmic_network.foo.vpc_id}"
 }
 
@@ -193,9 +192,16 @@ resource "cosmic_port_forward" "foo" {
 	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
-	COSMIC_DEFAULT_ALLOW_ACL_ID)
+)
 
 var testAccCosmicPortForward_update = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.10.0/24"
@@ -215,7 +221,7 @@ resource "cosmic_instance" "foo" {
 }
 
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "${cosmic_network.foo.vpc_id}"
 }
 
@@ -241,4 +247,4 @@ resource "cosmic_port_forward" "foo" {
 	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
-	COSMIC_DEFAULT_ALLOW_ACL_ID)
+)

--- a/cosmic/resource_cosmic_static_nat_test.go
+++ b/cosmic/resource_cosmic_static_nat_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func TestAccCosmicStaticNAT_basic(t *testing.T) {
-	if COSMIC_DEFAULT_ALLOW_ACL_ID == "" {
-		t.Skip("This test requires a \"default_allow\" ACL ID (set it by exporting COSMIC_DEFAULT_ALLOW_ACL_ID)")
-	}
-
 	if COSMIC_SERVICE_OFFERING_1 == "" {
 		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
 	}
@@ -116,6 +112,13 @@ func testAccCheckCosmicStaticNATDestroy(s *terraform.State) error {
 }
 
 var testAccCosmicStaticNAT_basic = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.10.0/24"
@@ -137,7 +140,7 @@ resource "cosmic_instance" "foo" {
 }
 
 resource "cosmic_ipaddress" "foo" {
-  acl_id = "%s"
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
   vpc_id = "${cosmic_network.foo.vpc_id}"
 }
 
@@ -150,4 +153,4 @@ resource "cosmic_static_nat" "foo" {
 	COSMIC_ZONE,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
-	COSMIC_DEFAULT_ALLOW_ACL_ID)
+)

--- a/cosmic/resource_cosmic_static_nat_test.go
+++ b/cosmic/resource_cosmic_static_nat_test.go
@@ -78,12 +78,10 @@ func testAccCheckCosmicStaticNATExists(
 	}
 }
 
-func testAccCheckCosmicStaticNATAttributes(
-	ipaddr *cosmic.PublicIpAddress) resource.TestCheckFunc {
+func testAccCheckCosmicStaticNATAttributes(ipaddr *cosmic.PublicIpAddress) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
-		if ipaddr.Associatednetworkname != "terraform-network" {
-			return fmt.Errorf("Bad network name: %s", ipaddr.Associatednetworkname)
+		if ipaddr.Virtualmachinename != "terraform-test" {
+			return fmt.Errorf("Bad network name: %s", ipaddr.Virtualmachinename)
 		}
 
 		return nil


### PR DESCRIPTION
As it says, introduces a `cosmic_network_acl` data source to look up network ACL lists.  This is then used in tests in place of the `COSMIC_DEFAULT_ALLOW_ACL_ID` shell variable.