### PR TITLE
Add support for port forward end ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## Unreleased
 
 - Add `cosmic_network_acl` data source to look up Network ACL Lists
+- Add `private_end_port` and `public_end_port` fields to `cosmic_port_forward`
 - Set `optimise_for` value when importing a Cosmic instance
 
 ## 0.3.1 (2019-08-06)

--- a/cosmic/resource_cosmic_port_forward_test.go
+++ b/cosmic/resource_cosmic_port_forward_test.go
@@ -87,6 +87,40 @@ func TestAccCosmicPortForward_update(t *testing.T) {
 	})
 }
 
+func TestAccCosmicPortForward_endPort(t *testing.T) {
+	if COSMIC_SERVICE_OFFERING_1 == "" {
+		t.Skip("This test requires an existing service offering (set it by exporting COSMIC_SERVICE_OFFERING_1)")
+	}
+
+	if COSMIC_TEMPLATE == "" {
+		t.Skip("This test requires an existing instance template (set it by exporting COSMIC_TEMPLATE)")
+	}
+
+	if COSMIC_VPC_ID == "" {
+		t.Skip("This test requires an existing VPC ID (set it by exporting COSMIC_VPC_ID)")
+	}
+
+	if COSMIC_VPC_NETWORK_OFFERING == "" {
+		t.Skip("This test requires an existing VPC network offering (set it by exporting COSMIC_VPC_NETWORK_OFFERING)")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCosmicPortForwardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCosmicPortForward_endPort,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCosmicPortForwardsExist("cosmic_port_forward.foo"),
+					resource.TestCheckResourceAttr(
+						"cosmic_port_forward.foo", "forward.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCosmicPortForwardsExist(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -239,6 +273,56 @@ resource "cosmic_port_forward" "foo" {
     protocol           = "tcp"
     private_port       = 80
     public_port        = 8080
+    virtual_machine_id = "${cosmic_instance.foo.id}"
+  }
+}`,
+	COSMIC_VPC_NETWORK_OFFERING,
+	COSMIC_VPC_ID,
+	COSMIC_ZONE,
+	COSMIC_SERVICE_OFFERING_1,
+	COSMIC_TEMPLATE,
+)
+
+var testAccCosmicPortForward_endPort = fmt.Sprintf(`
+data "cosmic_network_acl" "default_allow" {
+  filter {
+    name  = "name"
+    value = "default_allow"
+  }
+}
+
+resource "cosmic_network" "foo" {
+  name             = "terraform-network"
+  cidr             = "10.0.10.0/24"
+  gateway          = "10.0.10.1"
+  network_offering = "%s"
+  vpc_id           = "%s"
+  zone             = "%s"
+}
+
+resource "cosmic_instance" "foo" {
+  name             = "terraform-test"
+  service_offering = "%s"
+  network_id       = "${cosmic_network.foo.id}"
+  template         = "%s"
+  zone             = "${cosmic_network.foo.zone}"
+  expunge          = true
+}
+
+resource "cosmic_ipaddress" "foo" {
+  acl_id = "${data.cosmic_network_acl.default_allow.id}"
+  vpc_id = "${cosmic_network.foo.vpc_id}"
+}
+
+resource "cosmic_port_forward" "foo" {
+  ip_address_id = "${cosmic_ipaddress.foo.id}"
+
+  forward {
+    protocol           = "tcp"
+	private_port       = 443
+	private_end_port   = 444
+	public_port        = 443
+	public_end_port    = 444
     virtual_machine_id = "${cosmic_instance.foo.id}"
   }
 }`,


### PR DESCRIPTION
Adds `private_end_port` and `public_end_port` fields, also added some
more tests to validate port forward is created as expected.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>