### PR TITLE
Set zone via provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Add `zone` field to provider config and deprecate `zone` field on resources
+
 ## 0.4.2 (2020-04-22)
 
 - Add ability to rename `cosmic_network_acl`'s `name` and `description` fields

--- a/cosmic/client.go
+++ b/cosmic/client.go
@@ -6,4 +6,6 @@ import "github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 // Cosmic client whilst adding some bonus fields and methods.
 type CosmicClient struct {
 	*cosmic.CosmicClient
+
+	ZoneName string
 }

--- a/cosmic/client.go
+++ b/cosmic/client.go
@@ -1,0 +1,9 @@
+package cosmic
+
+import "github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
+
+// CosmicClient wraps CosmicClient to instantiate a new
+// Cosmic client whilst adding some bonus fields and methods.
+type CosmicClient struct {
+	*cosmic.CosmicClient
+}

--- a/cosmic/config.go
+++ b/cosmic/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	APIURL      string
 	APIKey      string
 	SecretKey   string
+	ZoneName    string
 	HTTPGETOnly bool
 	Timeout     int64
 }
@@ -17,5 +18,5 @@ func (c *Config) NewClient() (*CosmicClient, error) {
 	client := cosmic.NewAsyncClient(c.APIURL, c.APIKey, c.SecretKey, nil, 120)
 	client.HTTPGETOnly = c.HTTPGETOnly
 	client.AsyncTimeout(c.Timeout)
-	return &CosmicClient{CosmicClient: client}, nil
+	return &CosmicClient{CosmicClient: client, ZoneName: c.ZoneName}, nil
 }

--- a/cosmic/config.go
+++ b/cosmic/config.go
@@ -13,9 +13,9 @@ type Config struct {
 }
 
 // NewClient returns a new Cosmic client.
-func (c *Config) NewClient() (*cosmic.CosmicClient, error) {
-	cs := cosmic.NewAsyncClient(c.APIURL, c.APIKey, c.SecretKey, nil, 120)
-	cs.HTTPGETOnly = c.HTTPGETOnly
-	cs.AsyncTimeout(c.Timeout)
-	return cs, nil
+func (c *Config) NewClient() (*CosmicClient, error) {
+	client := cosmic.NewAsyncClient(c.APIURL, c.APIKey, c.SecretKey, nil, 120)
+	client.HTTPGETOnly = c.HTTPGETOnly
+	client.AsyncTimeout(c.Timeout)
+	return &CosmicClient{CosmicClient: client}, nil
 }

--- a/cosmic/data_source_cosmic_network_acl.go
+++ b/cosmic/data_source_cosmic_network_acl.go
@@ -39,12 +39,12 @@ func dataSourceCosmicNetworkACL() *schema.Resource {
 }
 
 func dataSourceCosmicNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
-	p := conn.NetworkACL.NewListNetworkACLListsParams()
+	p := client.NetworkACL.NewListNetworkACLListsParams()
 	p.SetListall(true)
 
-	cosmicACLLists, err := conn.NetworkACL.ListNetworkACLLists(p)
+	cosmicACLLists, err := client.NetworkACL.ListNetworkACLLists(p)
 	if err != nil {
 		return fmt.Errorf("Failed to list ACL Lists: %s", err)
 	}

--- a/cosmic/data_source_cosmic_network_acl_test.go
+++ b/cosmic/data_source_cosmic_network_acl_test.go
@@ -38,9 +38,9 @@ func testAccCheckCosmicNetworkACLDataSourceExists(n string, aclList *cosmic.Netw
 			return fmt.Errorf("Network ACL List data source ID not set")
 		}
 
-		conn := testAccProvider.Meta().(*cosmic.CosmicClient)
-		list, _, err := conn.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
 
+		list, _, err := client.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/cosmic/provider_test.go
+++ b/cosmic/provider_test.go
@@ -82,6 +82,3 @@ var COSMIC_VPC_NETWORK_OFFERING = os.Getenv("COSMIC_VPC_NETWORK_OFFERING")
 
 // Name of a template that exists already for building VMs
 var COSMIC_TEMPLATE = os.Getenv("COSMIC_TEMPLATE")
-
-// Name of a zone that exists already
-var COSMIC_ZONE = os.Getenv("COSMIC_ZONE")

--- a/cosmic/resource_cosmic_affinity_group.go
+++ b/cosmic/resource_cosmic_affinity_group.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -42,13 +41,13 @@ func resourceCosmicAffinityGroup() *schema.Resource {
 }
 
 func resourceCosmicAffinityGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	name := d.Get("name").(string)
 	affinityGroupType := d.Get("type").(string)
 
 	// Create a new parameter struct
-	p := cs.AffinityGroup.NewCreateAffinityGroupParams(name, affinityGroupType)
+	p := client.AffinityGroup.NewCreateAffinityGroupParams(name, affinityGroupType)
 
 	// Set the description
 	if description, ok := d.GetOk("description"); ok {
@@ -58,7 +57,7 @@ func resourceCosmicAffinityGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Creating affinity group %s", name)
-	r, err := cs.AffinityGroup.CreateAffinityGroup(p)
+	r, err := client.AffinityGroup.CreateAffinityGroup(p)
 	if err != nil {
 		return err
 	}
@@ -70,12 +69,12 @@ func resourceCosmicAffinityGroupCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceCosmicAffinityGroupRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	log.Printf("[DEBUG] Rerieving affinity group %s", d.Get("name").(string))
 
 	// Get the affinity group details
-	ag, count, err := cs.AffinityGroup.GetAffinityGroupByID(d.Id())
+	ag, count, err := client.AffinityGroup.GetAffinityGroupByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf("[DEBUG] Affinity group %s does not longer exist", d.Get("name").(string))
@@ -95,14 +94,14 @@ func resourceCosmicAffinityGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceCosmicAffinityGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.AffinityGroup.NewDeleteAffinityGroupParams()
+	p := client.AffinityGroup.NewDeleteAffinityGroupParams()
 	p.SetId(d.Id())
 
 	// Delete the affinity group
-	_, err := cs.AffinityGroup.DeleteAffinityGroup(p)
+	_, err := client.AffinityGroup.DeleteAffinityGroup(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_affinity_group_test.go
+++ b/cosmic/resource_cosmic_affinity_group_test.go
@@ -40,8 +40,8 @@ func testAccCheckCosmicAffinityGroupExists(n string, affinityGroup *cosmic.Affin
 			return fmt.Errorf("No affinity group ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		ag, _, err := cs.AffinityGroup.GetAffinityGroupByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		ag, _, err := client.AffinityGroup.GetAffinityGroupByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -77,7 +77,7 @@ func testAccCheckCosmicAffinityGroupAttributes(affinityGroup *cosmic.AffinityGro
 }
 
 func testAccCheckCosmicAffinityGroupDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_affinity_group" {
@@ -88,7 +88,7 @@ func testAccCheckCosmicAffinityGroupDestroy(s *terraform.State) error {
 			return fmt.Errorf("No affinity group ID is set")
 		}
 
-		_, _, err := cs.AffinityGroup.GetAffinityGroupByID(rs.Primary.ID)
+		_, _, err := client.AffinityGroup.GetAffinityGroupByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Affinity group %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_disk.go
+++ b/cosmic/resource_cosmic_disk.go
@@ -80,9 +80,11 @@ func resourceCosmicDisk() *schema.Resource {
 			},
 
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: deprecatedZoneMsg(),
 			},
 		},
 	}
@@ -117,7 +119,7 @@ func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", client.ZoneName)
 	if e != nil {
 		return e.Error()
 	}

--- a/cosmic/resource_cosmic_disk.go
+++ b/cosmic/resource_cosmic_disk.go
@@ -89,17 +89,17 @@ func resourceCosmicDisk() *schema.Resource {
 }
 
 func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 	d.Partial(true)
 
 	name := d.Get("name").(string)
 
 	// Create a new parameter struct
-	p := cs.Volume.NewCreateVolumeParams()
+	p := client.Volume.NewCreateVolumeParams()
 	p.SetName(name)
 
 	// Retrieve the disk_offering ID
-	diskofferingid, e := retrieveID(cs, "disk_offering", d.Get("disk_offering").(string))
+	diskofferingid, e := retrieveID(client, "disk_offering", d.Get("disk_offering").(string))
 	if e != nil {
 		return e.Error()
 	}
@@ -117,7 +117,7 @@ func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(cs, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
 	if e != nil {
 		return e.Error()
 	}
@@ -125,7 +125,7 @@ func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	p.SetZoneid(zoneid)
 
 	// Create the new volume
-	r, err := cs.Volume.CreateVolume(p)
+	r, err := client.Volume.CreateVolume(p)
 	if err != nil {
 		return fmt.Errorf("Error creating the new disk %s: %s", name, err)
 	}
@@ -155,10 +155,10 @@ func resourceCosmicDiskCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicDiskRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the volume details
-	v, count, err := cs.Volume.GetVolumeByID(d.Id())
+	v, count, err := client.Volume.GetVolumeByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			d.SetId("")
@@ -185,17 +185,17 @@ func resourceCosmicDiskRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicDiskUpdate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 	d.Partial(true)
 
 	name := d.Get("name").(string)
 
 	if d.HasChange("disk_offering") || d.HasChange("size") {
 		// Create a new parameter struct
-		p := cs.Volume.NewResizeVolumeParams(d.Id())
+		p := client.Volume.NewResizeVolumeParams(d.Id())
 
 		// Retrieve the disk_offering ID
-		diskofferingid, e := retrieveID(cs, "disk_offering", d.Get("disk_offering").(string))
+		diskofferingid, e := retrieveID(client, "disk_offering", d.Get("disk_offering").(string))
 		if e != nil {
 			return e.Error()
 		}
@@ -212,7 +212,7 @@ func resourceCosmicDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 		p.SetShrinkok(d.Get("shrink_ok").(bool))
 
 		// Change the disk_offering
-		r, err := cs.Volume.ResizeVolume(p)
+		r, err := client.Volume.ResizeVolume(p)
 		if err != nil {
 			return fmt.Errorf("Error changing disk offering/size for disk %s: %s", name, err)
 		}
@@ -255,7 +255,7 @@ func resourceCosmicDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicDiskDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Detach the volume
 	if err := resourceCosmicDiskDetach(d, meta); err != nil {
@@ -263,10 +263,10 @@ func resourceCosmicDiskDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create a new parameter struct
-	p := cs.Volume.NewDeleteVolumeParams(d.Id())
+	p := client.Volume.NewDeleteVolumeParams(d.Id())
 
 	// Delete the voluem
-	if _, err := cs.Volume.DeleteVolume(p); err != nil {
+	if _, err := client.Volume.DeleteVolume(p); err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(
 			"Invalid parameter id value=%s due to incorrect long value format, "+
@@ -281,7 +281,7 @@ func resourceCosmicDiskDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicDiskAttach(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	if virtualmachineid, ok := d.GetOk("virtual_machine_id"); ok {
 		// First check if the disk isn't already attached
@@ -290,14 +290,14 @@ func resourceCosmicDiskAttach(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// Create a new parameter struct
-		p := cs.Volume.NewAttachVolumeParams(d.Id(), virtualmachineid.(string))
+		p := client.Volume.NewAttachVolumeParams(d.Id(), virtualmachineid.(string))
 
 		if deviceid, ok := d.GetOk("device_id"); ok {
 			p.SetDeviceid(int64(deviceid.(int)))
 		}
 
 		// Attach the new volume
-		r, err := Retry(10, retryableAttachVolumeFunc(cs, p))
+		r, err := Retry(10, retryableAttachVolumeFunc(client, p))
 		if err != nil {
 			return fmt.Errorf("Error attaching volume to VM: %s", err)
 		}
@@ -309,7 +309,7 @@ func resourceCosmicDiskAttach(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicDiskDetach(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Check if the volume is actually attached, before detaching
 	if attached, err := isAttached(d, meta); err != nil || !attached {
@@ -317,33 +317,33 @@ func resourceCosmicDiskDetach(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create a new parameter struct
-	p := cs.Volume.NewDetachVolumeParams()
+	p := client.Volume.NewDetachVolumeParams()
 
 	// Set the volume ID
 	p.SetId(d.Id())
 
 	// Detach the currently attached volume
-	_, err := cs.Volume.DetachVolume(p)
+	_, err := client.Volume.DetachVolume(p)
 	if err != nil {
 		if virtualmachineid, ok := d.GetOk("virtual_machine_id"); ok {
 			// Create a new parameter struct
-			pd := cs.VirtualMachine.NewStopVirtualMachineParams(virtualmachineid.(string))
+			pd := client.VirtualMachine.NewStopVirtualMachineParams(virtualmachineid.(string))
 
 			// Stop the virtual machine in order to be able to detach the disk
-			if _, err := cs.VirtualMachine.StopVirtualMachine(pd); err != nil {
+			if _, err := client.VirtualMachine.StopVirtualMachine(pd); err != nil {
 				return err
 			}
 
 			// Try again to detach the currently attached volume
-			if _, err := cs.Volume.DetachVolume(p); err != nil {
+			if _, err := client.Volume.DetachVolume(p); err != nil {
 				return err
 			}
 
 			// Create a new parameter struct
-			pu := cs.VirtualMachine.NewStartVirtualMachineParams(virtualmachineid.(string))
+			pu := client.VirtualMachine.NewStartVirtualMachineParams(virtualmachineid.(string))
 
 			// Start the virtual machine again
-			if _, err := cs.VirtualMachine.StartVirtualMachine(pu); err != nil {
+			if _, err := client.VirtualMachine.StartVirtualMachine(pu); err != nil {
 				return err
 			}
 		}
@@ -353,10 +353,10 @@ func resourceCosmicDiskDetach(d *schema.ResourceData, meta interface{}) error {
 }
 
 func isAttached(d *schema.ResourceData, meta interface{}) (bool, error) {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the volume details
-	v, _, err := cs.Volume.GetVolumeByID(d.Id())
+	v, _, err := client.Volume.GetVolumeByID(d.Id())
 	if err != nil {
 		return false, err
 	}
@@ -364,10 +364,10 @@ func isAttached(d *schema.ResourceData, meta interface{}) (bool, error) {
 	return v.Attached != "", nil
 }
 
-func retryableAttachVolumeFunc(cs *cosmic.CosmicClient, p *cosmic.AttachVolumeParams) func() (interface{}, error) {
+func retryableAttachVolumeFunc(client *CosmicClient, p *cosmic.AttachVolumeParams) func() (interface{}, error) {
 	return func() (interface{}, error) {
 
-		r, err := cs.Volume.AttachVolume(p)
+		r, err := client.Volume.AttachVolume(p)
 		if err != nil {
 			return nil, err
 		}

--- a/cosmic/resource_cosmic_disk_test.go
+++ b/cosmic/resource_cosmic_disk_test.go
@@ -343,10 +343,8 @@ resource "cosmic_disk" "foo" {
   attach        = false
   size          = "10"
   disk_offering = "%s"
-  zone          = "%s"
 }`,
 	strings.ToLower(COSMIC_DISK_OFFERING),
-	COSMIC_ZONE,
 )
 
 var testAccCosmicDisk_update = fmt.Sprintf(`
@@ -355,10 +353,8 @@ resource "cosmic_disk" "foo" {
   attach        = false
   size          = "20"
   disk_offering = "%s"
-  zone          = "%s"
 }`,
 	COSMIC_DISK_OFFERING,
-	COSMIC_ZONE,
 )
 
 var testAccCosmicDisk_diskController = fmt.Sprintf(`
@@ -368,10 +364,8 @@ resource "cosmic_disk" "foo" {
   size            = "10"
   disk_offering   = "%s"
   disk_controller = "SCSI"
-  zone            = "%s"
 }`,
 	COSMIC_DISK_OFFERING,
-	COSMIC_ZONE,
 )
 
 var testAccCosmicDisk_attachBasic = fmt.Sprintf(`
@@ -381,7 +375,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -390,7 +383,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -399,7 +391,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -409,10 +400,8 @@ resource "cosmic_disk" "foo" {
   size               = "10"
   disk_offering      = "%s"
   virtual_machine_id = "${cosmic_instance.foo.id}"
-  zone               = "${cosmic_instance.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -426,7 +415,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -435,7 +423,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -444,7 +431,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -455,10 +441,8 @@ resource "cosmic_disk" "foo" {
   disk_offering      = "%s"
   disk_controller    = "SCSI"
   virtual_machine_id = "${cosmic_instance.foo.id}"
-  zone               = "${cosmic_instance.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -472,7 +456,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -481,7 +464,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -490,7 +472,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -501,10 +482,8 @@ resource "cosmic_disk" "foo" {
   size               = "10"
   disk_offering      = "%s"
   virtual_machine_id = "${cosmic_instance.foo.id}"
-  zone               = "${cosmic_instance.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -518,7 +497,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -527,7 +505,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -536,7 +513,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -546,10 +522,8 @@ resource "cosmic_disk" "foo" {
   size               = "20"
   disk_offering      = "%s"
   virtual_machine_id = "${cosmic_instance.foo.id}"
-  zone               = "${cosmic_instance.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_disk_test.go
+++ b/cosmic/resource_cosmic_disk_test.go
@@ -284,8 +284,8 @@ func testAccCheckCosmicDiskExists(n string, disk *cosmic.Volume) resource.TestCh
 			return fmt.Errorf("No disk ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		volume, _, err := cs.Volume.GetVolumeByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		volume, _, err := client.Volume.GetVolumeByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -317,7 +317,7 @@ func testAccCheckCosmicDiskAttributes(disk *cosmic.Volume) resource.TestCheckFun
 }
 
 func testAccCheckCosmicDiskDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_disk" {
@@ -328,7 +328,7 @@ func testAccCheckCosmicDiskDestroy(s *terraform.State) error {
 			return fmt.Errorf("No disk ID is set")
 		}
 
-		_, _, err := cs.Volume.GetVolumeByID(rs.Primary.ID)
+		_, _, err := client.Volume.GetVolumeByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Disk %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_instance.go
+++ b/cosmic/resource_cosmic_instance.go
@@ -90,12 +90,6 @@ func resourceCosmicInstance() *schema.Resource {
 				ConflictsWith: []string{"affinity_group_ids"},
 			},
 
-			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"keypair": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -146,6 +140,14 @@ func resourceCosmicInstance() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"zone": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: deprecatedZoneMsg(),
+			},
 		},
 	}
 }
@@ -160,7 +162,7 @@ func resourceCosmicInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", client.ZoneName)
 	if e != nil {
 		return e.Error()
 	}

--- a/cosmic/resource_cosmic_instance_test.go
+++ b/cosmic/resource_cosmic_instance_test.go
@@ -270,8 +270,8 @@ func testAccCheckCosmicInstanceExists(n string, instance *cosmic.VirtualMachine)
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		vm, _, err := cs.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		vm, _, err := client.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -340,7 +340,7 @@ func testAccCheckCosmicInstanceRenamedAndResized(instance *cosmic.VirtualMachine
 }
 
 func testAccCheckCosmicInstanceDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_instance" {
@@ -351,7 +351,7 @@ func testAccCheckCosmicInstanceDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, _, err := cs.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
+		_, _, err := client.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Virtual Machine %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_instance_test.go
+++ b/cosmic/resource_cosmic_instance_test.go
@@ -367,7 +367,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -376,7 +375,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -385,12 +383,10 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	strings.ToLower(COSMIC_SERVICE_OFFERING_1),
 	COSMIC_TEMPLATE,
@@ -403,7 +399,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -412,7 +407,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -421,12 +415,10 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_2,
 	COSMIC_TEMPLATE,
@@ -439,7 +431,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -448,7 +439,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -457,13 +447,11 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   disk_controller  = "SCSI"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -476,7 +464,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -485,7 +472,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -495,11 +481,9 @@ resource "cosmic_instance" "foo" {
   network_id       = "${cosmic_network.foo.id}"
   ip_address       = "10.0.10.10"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -513,7 +497,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -522,7 +505,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_ssh_keypair" "foo" {
@@ -536,12 +518,10 @@ resource "cosmic_instance" "foo" {
   network_id       = "${cosmic_network.foo.id}"
   ip_address       = "10.0.10.10"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   keypair          = "${cosmic_ssh_keypair.foo.name}"
   expunge          = true
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_NETWORK_OFFERING,
 		keyPairName,
 		COSMIC_SERVICE_OFFERING_1,

--- a/cosmic/resource_cosmic_ipaddress_test.go
+++ b/cosmic/resource_cosmic_ipaddress_test.go
@@ -45,8 +45,8 @@ func testAccCheckCosmicIPAddressExists(n string, ipaddr *cosmic.PublicIpAddress)
 			return fmt.Errorf("No IP address ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		pip, _, err := cs.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		pip, _, err := client.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -80,7 +80,7 @@ func testAccCheckCosmicIPAddressAttributes(ipaddr *cosmic.PublicIpAddress) resou
 }
 
 func testAccCheckCosmicIPAddressDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_ipaddress" {
@@ -91,7 +91,7 @@ func testAccCheckCosmicIPAddressDestroy(s *terraform.State) error {
 			return fmt.Errorf("No IP address ID is set")
 		}
 
-		ip, _, err := cs.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
+		ip, _, err := client.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
 		if err == nil && ip.Associatednetworkid != "" {
 			return fmt.Errorf("Public IP %s still associated", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_ipaddress_test.go
+++ b/cosmic/resource_cosmic_ipaddress_test.go
@@ -107,7 +107,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 data "cosmic_network_acl" "default_allow" {
@@ -122,5 +121,4 @@ resource "cosmic_ipaddress" "foo" {
   vpc_id = "${cosmic_vpc.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_loadbalancer_rule_test.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule_test.go
@@ -392,8 +392,8 @@ func testAccCheckCosmicLoadBalancerRuleExist(n string, id *string, rule *cosmic.
 			*id = rs.Primary.ID
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		lbrule, count, err := cs.LoadBalancer.GetLoadBalancerRuleByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*cosmic.CosmicClient)
+		lbrule, count, err := client.LoadBalancer.GetLoadBalancerRuleByID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -462,7 +462,7 @@ func testAccCheckCosmicLoadBalancerRuleAttributes(rule *cosmic.LoadBalancerRule,
 }
 
 func testAccCheckCosmicLoadBalancerRuleDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*cosmic.CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_loadbalancer_rule" {
@@ -478,7 +478,7 @@ func testAccCheckCosmicLoadBalancerRuleDestroy(s *terraform.State) error {
 				continue
 			}
 
-			_, _, err := cs.LoadBalancer.GetLoadBalancerRuleByID(id)
+			_, _, err := client.LoadBalancer.GetLoadBalancerRuleByID(id)
 			if err == nil {
 				return fmt.Errorf("Loadbalancer rule %s still exists", rs.Primary.ID)
 			}

--- a/cosmic/resource_cosmic_loadbalancer_rule_test.go
+++ b/cosmic/resource_cosmic_loadbalancer_rule_test.go
@@ -392,7 +392,7 @@ func testAccCheckCosmicLoadBalancerRuleExist(n string, id *string, rule *cosmic.
 			*id = rs.Primary.ID
 		}
 
-		client := testAccProvider.Meta().(*cosmic.CosmicClient)
+		client := testAccProvider.Meta().(*CosmicClient)
 		lbrule, count, err := client.LoadBalancer.GetLoadBalancerRuleByID(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -462,7 +462,7 @@ func testAccCheckCosmicLoadBalancerRuleAttributes(rule *cosmic.LoadBalancerRule,
 }
 
 func testAccCheckCosmicLoadBalancerRuleDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_loadbalancer_rule" {
@@ -496,7 +496,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -505,7 +504,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 data "cosmic_network_acl" "default_allow" {
@@ -526,7 +524,6 @@ resource "cosmic_instance" "foo1" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -540,7 +537,6 @@ resource "cosmic_loadbalancer_rule" "foo" {
   member_ids    = ["${cosmic_instance.foo1.id}"]
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_NETWORK_OFFERING,
 		COSMIC_SERVICE_OFFERING_1,
 		COSMIC_TEMPLATE,
@@ -559,7 +555,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -568,7 +563,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 data "cosmic_network_acl" "default_allow" {
@@ -589,7 +583,6 @@ resource "cosmic_instance" "foo1" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -599,7 +592,6 @@ resource "cosmic_instance" "foo2" {
   service_offering = "${cosmic_instance.foo1.service_offering}"
   network_id       = "${cosmic_network.foo.id}"
   template         = "${cosmic_instance.foo1.template}"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -613,7 +605,6 @@ resource "cosmic_loadbalancer_rule" "foo" {
   member_ids    = ["${cosmic_instance.foo1.id}", "${cosmic_instance.foo2.id}"]
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_NETWORK_OFFERING,
 		COSMIC_SERVICE_OFFERING_1,
 		COSMIC_TEMPLATE,
@@ -632,7 +623,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -641,7 +631,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 data "cosmic_network_acl" "default_allow" {
@@ -662,7 +651,6 @@ resource "cosmic_instance" "foo1" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -677,7 +665,6 @@ resource "cosmic_loadbalancer_rule" "foo" {
   member_ids    = ["${cosmic_instance.foo1.id}"]
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_NETWORK_OFFERING,
 		COSMIC_SERVICE_OFFERING_1,
 		COSMIC_TEMPLATE,
@@ -697,7 +684,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -706,7 +692,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 data "cosmic_network_acl" "default_allow" {
@@ -727,7 +712,6 @@ resource "cosmic_instance" "foo1" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   expunge          = true
 }
 
@@ -743,7 +727,6 @@ resource "cosmic_loadbalancer_rule" "foo" {
   member_ids     = ["${cosmic_instance.foo1.id}"]
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_NETWORK_OFFERING,
 		COSMIC_SERVICE_OFFERING_1,
 		COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_network.go
+++ b/cosmic/resource_cosmic_network.go
@@ -121,9 +121,11 @@ func resourceCosmicNetwork() *schema.Resource {
 			},
 
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: deprecatedZoneMsg(),
 			},
 
 			"tags": tagsSchema(),
@@ -143,7 +145,7 @@ func resourceCosmicNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", client.ZoneName)
 	if e != nil {
 		return e.Error()
 	}

--- a/cosmic/resource_cosmic_network_acl.go
+++ b/cosmic/resource_cosmic_network_acl.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -41,12 +40,12 @@ func resourceCosmicNetworkACL() *schema.Resource {
 }
 
 func resourceCosmicNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	name := d.Get("name").(string)
 
 	// Create a new parameter struct
-	p := cs.NetworkACL.NewCreateNetworkACLListParams(name, d.Get("vpc_id").(string))
+	p := client.NetworkACL.NewCreateNetworkACLListParams(name, d.Get("vpc_id").(string))
 
 	// Set the description
 	if description, ok := d.GetOk("description"); ok {
@@ -56,7 +55,7 @@ func resourceCosmicNetworkACLCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// Create the new network ACL list
-	r, err := cs.NetworkACL.CreateNetworkACLList(p)
+	r, err := client.NetworkACL.CreateNetworkACLList(p)
 	if err != nil {
 		return fmt.Errorf("Error creating network ACL list %s: %s", name, err)
 	}
@@ -67,10 +66,10 @@ func resourceCosmicNetworkACLCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCosmicNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the network ACL list details
-	f, count, err := cs.NetworkACL.GetNetworkACLListByID(d.Id())
+	f, count, err := client.NetworkACL.GetNetworkACLListByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -90,11 +89,11 @@ func resourceCosmicNetworkACLRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceCosmicNetworkACLUpdate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 	name := d.Get("name").(string)
 
 	// Create a new parameter struct
-	p := cs.NetworkACL.NewUpdateNetworkACLListParams(d.Id())
+	p := client.NetworkACL.NewUpdateNetworkACLListParams(d.Id())
 
 	// Check if the name or description is changed
 	if d.HasChange("name") || d.HasChange("description") {
@@ -109,7 +108,7 @@ func resourceCosmicNetworkACLUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// Update the network ACL
-	_, err := cs.NetworkACL.UpdateNetworkACLList(p)
+	_, err := client.NetworkACL.UpdateNetworkACLList(p)
 	if err != nil {
 		return fmt.Errorf(
 			"Error updating network ACL %s: %s", name, err)
@@ -119,14 +118,14 @@ func resourceCosmicNetworkACLUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCosmicNetworkACLDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.NetworkACL.NewDeleteNetworkACLListParams(d.Id())
+	p := client.NetworkACL.NewDeleteNetworkACLListParams(d.Id())
 
 	// Delete the network ACL list
 	_, err := Retry(3, func() (interface{}, error) {
-		return cs.NetworkACL.DeleteNetworkACLList(p)
+		return client.NetworkACL.DeleteNetworkACLList(p)
 	})
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(

--- a/cosmic/resource_cosmic_network_acl_rule_test.go
+++ b/cosmic/resource_cosmic_network_acl_rule_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -277,8 +276,8 @@ func testAccCheckCosmicNetworkACLRulesExist(n string) resource.TestCheckFunc {
 				continue
 			}
 
-			cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-			_, count, err := cs.NetworkACL.GetNetworkACLByID(id)
+			client := testAccProvider.Meta().(*CosmicClient)
+			_, count, err := client.NetworkACL.GetNetworkACLByID(id)
 
 			if err != nil {
 				return err
@@ -294,7 +293,7 @@ func testAccCheckCosmicNetworkACLRulesExist(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckCosmicNetworkACLRuleDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_network_acl_rule" {
@@ -310,7 +309,7 @@ func testAccCheckCosmicNetworkACLRuleDestroy(s *terraform.State) error {
 				continue
 			}
 
-			_, _, err := cs.NetworkACL.GetNetworkACLByID(id)
+			_, _, err := client.NetworkACL.GetNetworkACLByID(id)
 			if err == nil {
 				return fmt.Errorf("Network ACL rule %s still exists", rs.Primary.ID)
 			}

--- a/cosmic/resource_cosmic_network_acl_rule_test.go
+++ b/cosmic/resource_cosmic_network_acl_rule_test.go
@@ -326,7 +326,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 resource "cosmic_network_acl" "foo" {
@@ -369,7 +368,6 @@ resource "cosmic_network_acl_rule" "foo" {
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )
 
 var testAccCosmicNetworkACLRule_update = fmt.Sprintf(`
@@ -379,7 +377,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 resource "cosmic_network_acl" "foo" {
@@ -431,5 +428,4 @@ resource "cosmic_network_acl_rule" "foo" {
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_network_acl_test.go
+++ b/cosmic/resource_cosmic_network_acl_test.go
@@ -79,7 +79,7 @@ func testAccCheckCosmicNetworkACLExists(n string, id *string, acl *cosmic.Networ
 			*id = rs.Primary.ID
 		}
 
-		client := testAccProvider.Meta().(*cosmic.CosmicClient)
+		client := testAccProvider.Meta().(*CosmicClient)
 		acllist, count, err := client.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -116,7 +116,7 @@ func testAccCheckCosmicNetworkACLBasicAttributes(acl *cosmic.NetworkACLList, wan
 }
 
 func testAccCheckCosmicNetworkACLDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_network_acl" {
@@ -144,7 +144,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 resource "cosmic_network_acl" "foo" {
@@ -153,7 +152,6 @@ resource "cosmic_network_acl" "foo" {
   vpc_id      = "${cosmic_vpc.foo.id}"
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		attr.Name,
 		attr.Description,
 	)

--- a/cosmic/resource_cosmic_network_acl_test.go
+++ b/cosmic/resource_cosmic_network_acl_test.go
@@ -79,8 +79,8 @@ func testAccCheckCosmicNetworkACLExists(n string, id *string, acl *cosmic.Networ
 			*id = rs.Primary.ID
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		acllist, count, err := cs.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*cosmic.CosmicClient)
+		acllist, count, err := client.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ func testAccCheckCosmicNetworkACLBasicAttributes(acl *cosmic.NetworkACLList, wan
 }
 
 func testAccCheckCosmicNetworkACLDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*cosmic.CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_network_acl" {
@@ -127,7 +127,7 @@ func testAccCheckCosmicNetworkACLDestroy(s *terraform.State) error {
 			return fmt.Errorf("No network ACL ID is set")
 		}
 
-		_, _, err := cs.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
+		_, _, err := client.NetworkACL.GetNetworkACLListByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Network ACl list %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_network_test.go
+++ b/cosmic/resource_cosmic_network_test.go
@@ -175,8 +175,8 @@ func testAccCheckCosmicNetworkExists(n string, network *cosmic.Network) resource
 			return fmt.Errorf("No network ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		ntwrk, _, err := cs.Network.GetNetworkByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		ntwrk, _, err := client.Network.GetNetworkByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -222,7 +222,7 @@ func testAccCheckNetworkTags(n *cosmic.Network, key string, value string) resour
 }
 
 func testAccCheckCosmicNetworkDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_network" {
@@ -233,7 +233,7 @@ func testAccCheckCosmicNetworkDestroy(s *terraform.State) error {
 			return fmt.Errorf("No network ID is set")
 		}
 
-		_, _, err := cs.Network.GetNetworkByID(rs.Primary.ID)
+		_, _, err := client.Network.GetNetworkByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Network %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_network_test.go
+++ b/cosmic/resource_cosmic_network_test.go
@@ -249,7 +249,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -258,14 +257,12 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 
   tags = {
     terraform-tag = "true"
   }
 }`,
 	strings.ToLower(COSMIC_VPC_OFFERING),
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 )
 
@@ -276,7 +273,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -286,14 +282,12 @@ resource "cosmic_network" "foo" {
   dns              = ["10.10.10.10"]
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 
   tags = {
     terraform-tag = "true"
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 )
 
@@ -304,7 +298,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -314,14 +307,12 @@ resource "cosmic_network" "foo" {
   dns              = ["10.10.10.10"]
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 
   tags = {
     terraform-tag = "true"
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 )
 
@@ -332,7 +323,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network_acl" "foo" {
@@ -347,10 +337,8 @@ resource "cosmic_network" "foo" {
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
   acl_id           = "${cosmic_network_acl.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 )
 
@@ -361,7 +349,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network_acl" "bar" {
@@ -376,9 +363,7 @@ resource "cosmic_network" "foo" {
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
   acl_id           = "${cosmic_network_acl.bar.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 )

--- a/cosmic/resource_cosmic_nic_test.go
+++ b/cosmic/resource_cosmic_nic_test.go
@@ -191,7 +191,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -200,7 +199,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_network" "bar" {
@@ -209,7 +207,6 @@ resource "cosmic_network" "bar" {
   gateway          = "10.0.11.1"
   network_offering = "${cosmic_network.foo.network_offering}"
   vpc_id           = "${cosmic_network.foo.vpc_id}"
-  zone             = "${cosmic_network.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -218,7 +215,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   expunge          = true
 }
 
@@ -227,7 +223,6 @@ resource "cosmic_nic" "bar" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -240,7 +235,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -249,7 +243,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_network" "bar" {
@@ -258,7 +251,6 @@ resource "cosmic_network" "bar" {
   gateway          = "10.0.11.1"
   network_offering = "${cosmic_network.foo.network_offering}"
   vpc_id           = "${cosmic_network.foo.vpc_id}"
-  zone             = "${cosmic_network.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -267,7 +259,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   expunge          = true
 }
 
@@ -277,7 +268,6 @@ resource "cosmic_nic" "bar" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_nic_test.go
+++ b/cosmic/resource_cosmic_nic_test.go
@@ -118,8 +118,8 @@ func testAccCheckCosmicNICExists(v, n string, nic *cosmic.Nic) resource.TestChec
 			return fmt.Errorf("No NIC ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		vm, _, err := cs.VirtualMachine.GetVirtualMachineByID(rsv.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		vm, _, err := client.VirtualMachine.GetVirtualMachineByID(rsv.Primary.ID)
 
 		if err != nil {
 			return err
@@ -163,7 +163,7 @@ func testAccCheckCosmicNICIPAddress(nic *cosmic.Nic) resource.TestCheckFunc {
 }
 
 func testAccCheckCosmicNICDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	// Deleting the instance automatically deletes any additional NICs
 	for _, rs := range s.RootModule().Resources {
@@ -175,7 +175,7 @@ func testAccCheckCosmicNICDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, _, err := cs.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
+		_, _, err := client.VirtualMachine.GetVirtualMachineByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Virtual Machine %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_port_forward_test.go
+++ b/cosmic/resource_cosmic_port_forward_test.go
@@ -182,7 +182,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -191,7 +190,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -199,7 +197,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   expunge          = true
 }
 
@@ -226,7 +223,6 @@ resource "cosmic_port_forward" "foo" {
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -239,7 +235,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -248,7 +243,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -256,7 +250,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   expunge          = true
 }
 
@@ -290,7 +283,6 @@ resource "cosmic_port_forward" "foo" {
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -303,7 +295,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -312,7 +303,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -320,7 +310,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   expunge          = true
 }
 
@@ -349,7 +338,6 @@ resource "cosmic_port_forward" "foo" {
   }
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_port_forward_test.go
+++ b/cosmic/resource_cosmic_port_forward_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -133,8 +132,8 @@ func testAccCheckCosmicPortForwardsExist(n string) resource.TestCheckFunc {
 				continue
 			}
 
-			cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-			_, count, err := cs.Firewall.GetPortForwardingRuleByID(id)
+			client := testAccProvider.Meta().(*CosmicClient)
+			_, count, err := client.Firewall.GetPortForwardingRuleByID(id)
 
 			if err != nil {
 				return err
@@ -150,7 +149,7 @@ func testAccCheckCosmicPortForwardsExist(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckCosmicPortForwardDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_port_forward" {
@@ -166,7 +165,7 @@ func testAccCheckCosmicPortForwardDestroy(s *terraform.State) error {
 				continue
 			}
 
-			_, _, err := cs.Firewall.GetPortForwardingRuleByID(id)
+			_, _, err := client.Firewall.GetPortForwardingRuleByID(id)
 			if err == nil {
 				return fmt.Errorf("Port forward %s still exists", rs.Primary.ID)
 			}

--- a/cosmic/resource_cosmic_private_gateway.go
+++ b/cosmic/resource_cosmic_private_gateway.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -47,12 +46,12 @@ func resourceCosmicPrivateGateway() *schema.Resource {
 }
 
 func resourceCosmicPrivateGatewayCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	ipaddress := d.Get("ip_address").(string)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewCreatePrivateGatewayParams(
+	p := client.VPC.NewCreatePrivateGatewayParams(
 		ipaddress,
 		d.Get("network_id").(string),
 		d.Get("vpc_id").(string),
@@ -62,7 +61,7 @@ func resourceCosmicPrivateGatewayCreate(d *schema.ResourceData, meta interface{}
 	p.SetAclid(d.Get("acl_id").(string))
 
 	// Create the new private gateway
-	r, err := cs.VPC.CreatePrivateGateway(p)
+	r, err := client.VPC.CreatePrivateGateway(p)
 	if err != nil {
 		return fmt.Errorf("Error creating private gateway for %s: %s", ipaddress, err)
 	}
@@ -73,10 +72,10 @@ func resourceCosmicPrivateGatewayCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceCosmicPrivateGatewayRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the private gateway details
-	gw, count, err := cs.VPC.GetPrivateGatewayByID(d.Id())
+	gw, count, err := client.VPC.GetPrivateGatewayByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf("[DEBUG] Private gateway %s does no longer exist", d.Id())
@@ -96,13 +95,13 @@ func resourceCosmicPrivateGatewayRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceCosmicPrivateGatewayDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewDeletePrivateGatewayParams(d.Id())
+	p := client.VPC.NewDeletePrivateGatewayParams(d.Id())
 
 	// Delete the private gateway
-	_, err := cs.VPC.DeletePrivateGateway(p)
+	_, err := client.VPC.DeletePrivateGateway(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_private_gateway_test.go
+++ b/cosmic/resource_cosmic_private_gateway_test.go
@@ -44,8 +44,8 @@ func testAccCheckCosmicPrivateGatewayExists(n string, gateway *cosmic.PrivateGat
 			return fmt.Errorf("No Private Gateway ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		pgw, _, err := cs.VPC.GetPrivateGatewayByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		pgw, _, err := client.VPC.GetPrivateGatewayByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -73,7 +73,7 @@ func testAccCheckCosmicPrivateGatewayAttributes(gateway *cosmic.PrivateGateway) 
 }
 
 func testAccCheckCosmicPrivateGatewayDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_private_gateway" {
@@ -84,7 +84,7 @@ func testAccCheckCosmicPrivateGatewayDestroy(s *terraform.State) error {
 			return fmt.Errorf("No private gateway ID is set")
 		}
 
-		gateway, _, err := cs.VPC.GetPrivateGatewayByID(rs.Primary.ID)
+		gateway, _, err := client.VPC.GetPrivateGatewayByID(rs.Primary.ID)
 		if err == nil && gateway.Id != "" {
 			return fmt.Errorf("Private gateway %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_private_gateway_test.go
+++ b/cosmic/resource_cosmic_private_gateway_test.go
@@ -100,14 +100,12 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
   name             = "terraform-network"
   cidr             = "10.0.252.0/24"
   network_offering = "DefaultPrivateGatewayNetworkOffering"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_network_acl" "foo" {
@@ -122,5 +120,4 @@ resource "cosmic_private_gateway" "foo" {
   vpc_id     = "${cosmic_network_acl.foo.vpc_id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_secondary_ipaddress_test.go
+++ b/cosmic/resource_cosmic_secondary_ipaddress_test.go
@@ -62,7 +62,7 @@ func testAccCheckCosmicSecondaryIPAddressExists(n string, ip *cosmic.AddIpToNicR
 			return fmt.Errorf("No IP address ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+		client := testAccProvider.Meta().(*CosmicClient)
 
 		virtualmachine, ok := rs.Primary.Attributes["virtual_machine_id"]
 		if !ok {
@@ -70,13 +70,13 @@ func testAccCheckCosmicSecondaryIPAddressExists(n string, ip *cosmic.AddIpToNicR
 		}
 
 		// Retrieve the virtual_machine ID
-		virtualmachineid, e := retrieveID(cs, "virtual_machine", virtualmachine)
+		virtualmachineid, e := retrieveID(client, "virtual_machine", virtualmachine)
 		if e != nil {
 			return e.Error()
 		}
 
 		// Get the virtual machine details
-		vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(virtualmachineid)
+		vm, count, err := client.VirtualMachine.GetVirtualMachineByID(virtualmachineid)
 		if err != nil {
 			if count == 0 {
 				return fmt.Errorf("Instance not found")
@@ -92,10 +92,10 @@ func testAccCheckCosmicSecondaryIPAddressExists(n string, ip *cosmic.AddIpToNicR
 			nicid = vm.Nic[0].Id
 		}
 
-		p := cs.Nic.NewListNicsParams(virtualmachineid)
+		p := client.Nic.NewListNicsParams(virtualmachineid)
 		p.SetNicid(nicid)
 
-		l, err := cs.Nic.ListNics(p)
+		l, err := client.Nic.ListNics(p)
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func testAccCheckCosmicSecondaryIPAddressAttributes(ip *cosmic.AddIpToNicRespons
 }
 
 func testAccCheckCosmicSecondaryIPAddressDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_secondary_ipaddress" {
@@ -148,13 +148,13 @@ func testAccCheckCosmicSecondaryIPAddressDestroy(s *terraform.State) error {
 		}
 
 		// Retrieve the virtual_machine ID
-		virtualmachineid, e := retrieveID(cs, "virtual_machine", virtualmachine)
+		virtualmachineid, e := retrieveID(client, "virtual_machine", virtualmachine)
 		if e != nil {
 			return e.Error()
 		}
 
 		// Get the virtual machine details
-		vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(virtualmachineid)
+		vm, count, err := client.VirtualMachine.GetVirtualMachineByID(virtualmachineid)
 		if err != nil {
 			if count == 0 {
 				return nil
@@ -170,10 +170,10 @@ func testAccCheckCosmicSecondaryIPAddressDestroy(s *terraform.State) error {
 			nicid = vm.Nic[0].Id
 		}
 
-		p := cs.Nic.NewListNicsParams(virtualmachineid)
+		p := client.Nic.NewListNicsParams(virtualmachineid)
 		p.SetNicid(nicid)
 
-		l, err := cs.Nic.ListNics(p)
+		l, err := client.Nic.ListNics(p)
 		if err != nil {
 			return err
 		}

--- a/cosmic/resource_cosmic_secondary_ipaddress_test.go
+++ b/cosmic/resource_cosmic_secondary_ipaddress_test.go
@@ -205,7 +205,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -214,7 +213,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -223,7 +221,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }
@@ -232,7 +229,6 @@ resource "cosmic_secondary_ipaddress" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,
@@ -245,7 +241,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -254,7 +249,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -263,7 +257,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_vpc.foo.zone}"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }
@@ -273,7 +266,6 @@ resource "cosmic_secondary_ipaddress" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_ssh_keypair.go
+++ b/cosmic/resource_cosmic_ssh_keypair.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -45,24 +44,24 @@ func resourceCosmicSSHKeyPair() *schema.Resource {
 }
 
 func resourceCosmicSSHKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	name := d.Get("name").(string)
 	publicKey := d.Get("public_key").(string)
 
 	if publicKey != "" {
 		// Register supplied key
-		p := cs.SSH.NewRegisterSSHKeyPairParams(name, publicKey)
+		p := client.SSH.NewRegisterSSHKeyPairParams(name, publicKey)
 
-		_, err := cs.SSH.RegisterSSHKeyPair(p)
+		_, err := client.SSH.RegisterSSHKeyPair(p)
 		if err != nil {
 			return err
 		}
 	} else {
 		// No key supplied, must create one and return the private key
-		p := cs.SSH.NewCreateSSHKeyPairParams(name)
+		p := client.SSH.NewCreateSSHKeyPairParams(name)
 
-		r, err := cs.SSH.CreateSSHKeyPair(p)
+		r, err := client.SSH.CreateSSHKeyPair(p)
 		if err != nil {
 			return err
 		}
@@ -76,14 +75,14 @@ func resourceCosmicSSHKeyPairCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCosmicSSHKeyPairRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	log.Printf("[DEBUG] looking for key pair with name %s", d.Id())
 
-	p := cs.SSH.NewListSSHKeyPairsParams()
+	p := client.SSH.NewListSSHKeyPairsParams()
 	p.SetName(d.Id())
 
-	r, err := cs.SSH.ListSSHKeyPairs(p)
+	r, err := client.SSH.ListSSHKeyPairs(p)
 	if err != nil {
 		return err
 	}
@@ -101,13 +100,13 @@ func resourceCosmicSSHKeyPairRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceCosmicSSHKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.SSH.NewDeleteSSHKeyPairParams(d.Id())
+	p := client.SSH.NewDeleteSSHKeyPairParams(d.Id())
 
 	// Remove the SSH Keypair
-	_, err := cs.SSH.DeleteSSHKeyPair(p)
+	_, err := client.SSH.DeleteSSHKeyPair(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_ssh_keypair_test.go
+++ b/cosmic/resource_cosmic_ssh_keypair_test.go
@@ -68,11 +68,11 @@ func testAccCheckCosmicSSHKeyPairExists(n string, sshkey *cosmic.SSHKeyPair) res
 			return fmt.Errorf("No key pair ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		p := cs.SSH.NewListSSHKeyPairsParams()
+		client := testAccProvider.Meta().(*CosmicClient)
+		p := client.SSH.NewListSSHKeyPairsParams()
 		p.SetName(rs.Primary.ID)
 
-		list, err := cs.SSH.ListSSHKeyPairs(p)
+		list, err := client.SSH.ListSSHKeyPairs(p)
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func testAccCheckCosmicSSHKeyPairCreateAttributes(name string) resource.TestChec
 }
 
 func testAccCheckCosmicSSHKeyPairDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_ssh_keypair" {
@@ -142,10 +142,10 @@ func testAccCheckCosmicSSHKeyPairDestroy(s *terraform.State) error {
 			return fmt.Errorf("No key pair ID is set")
 		}
 
-		p := cs.SSH.NewListSSHKeyPairsParams()
+		p := client.SSH.NewListSSHKeyPairsParams()
 		p.SetName(rs.Primary.ID)
 
-		list, err := cs.SSH.ListSSHKeyPairs(p)
+		list, err := client.SSH.ListSSHKeyPairs(p)
 		if err != nil {
 			return err
 		}

--- a/cosmic/resource_cosmic_static_nat_test.go
+++ b/cosmic/resource_cosmic_static_nat_test.go
@@ -116,7 +116,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_network" "foo" {
@@ -125,7 +124,6 @@ resource "cosmic_network" "foo" {
   gateway          = "10.0.10.1"
   network_offering = "%s"
   vpc_id           = "${cosmic_vpc.foo.id}"
-  zone             = "${cosmic_vpc.foo.zone}"
 }
 
 resource "cosmic_instance" "foo" {
@@ -134,7 +132,6 @@ resource "cosmic_instance" "foo" {
   service_offering = "%s"
   network_id       = "${cosmic_network.foo.id}"
   template         = "%s"
-  zone             = "${cosmic_network.foo.zone}"
   user_data        = "foobar\nfoo\nbar"
   expunge          = true
 }
@@ -156,7 +153,6 @@ resource "cosmic_static_nat" "foo" {
   virtual_machine_id = "${cosmic_instance.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 	COSMIC_VPC_NETWORK_OFFERING,
 	COSMIC_SERVICE_OFFERING_1,
 	COSMIC_TEMPLATE,

--- a/cosmic/resource_cosmic_static_nat_test.go
+++ b/cosmic/resource_cosmic_static_nat_test.go
@@ -57,8 +57,8 @@ func testAccCheckCosmicStaticNATExists(n string, ipaddr *cosmic.PublicIpAddress)
 			return fmt.Errorf("No static NAT ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		ip, _, err := cs.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		ip, _, err := client.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func testAccCheckCosmicStaticNATAttributes(ipaddr *cosmic.PublicIpAddress) resou
 }
 
 func testAccCheckCosmicStaticNATDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_static_nat" {
@@ -100,7 +100,7 @@ func testAccCheckCosmicStaticNATDestroy(s *terraform.State) error {
 			return fmt.Errorf("No static NAT ID is set")
 		}
 
-		ip, _, err := cs.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
+		ip, _, err := client.PublicIPAddress.GetPublicIpAddressByID(rs.Primary.ID)
 		if err == nil && ip.Isstaticnat {
 			return fmt.Errorf("Static NAT %s still enabled", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_static_route.go
+++ b/cosmic/resource_cosmic_static_route.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -41,17 +40,17 @@ func resourceCosmicStaticRoute() *schema.Resource {
 }
 
 func resourceCosmicStaticRouteCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewCreateStaticRouteParams(
+	p := client.VPC.NewCreateStaticRouteParams(
 		d.Get("cidr").(string),
 		d.Get("nexthop").(string),
 		d.Get("vpc_id").(string),
 	)
 
 	// Create the new private gateway
-	r, err := cs.VPC.CreateStaticRoute(p)
+	r, err := client.VPC.CreateStaticRoute(p)
 	if err != nil {
 		return fmt.Errorf("Error creating static route for %s: %s", d.Get("cidr").(string), err)
 	}
@@ -62,10 +61,10 @@ func resourceCosmicStaticRouteCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceCosmicStaticRouteRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the virtual machine details
-	route, count, err := cs.VPC.GetStaticRouteByID(d.Id())
+	route, count, err := client.VPC.GetStaticRouteByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf("[DEBUG] Static route %s does no longer exist", d.Id())
@@ -84,13 +83,13 @@ func resourceCosmicStaticRouteRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceCosmicStaticRouteDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewDeleteStaticRouteParams(d.Id())
+	p := client.VPC.NewDeleteStaticRouteParams(d.Id())
 
 	// Delete the private gateway
-	_, err := cs.VPC.DeleteStaticRoute(p)
+	_, err := client.VPC.DeleteStaticRoute(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_static_route_test.go
+++ b/cosmic/resource_cosmic_static_route_test.go
@@ -101,7 +101,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   network_domain = "terraform-domain"
   vpc_offering   = "%s"
-  zone           = "%s"
 }
 
 resource "cosmic_static_route" "foo" {
@@ -110,5 +109,4 @@ resource "cosmic_static_route" "foo" {
   vpc_id  = "${cosmic_vpc.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_static_route_test.go
+++ b/cosmic/resource_cosmic_static_route_test.go
@@ -45,8 +45,8 @@ func testAccCheckCosmicStaticRouteExists(n string, route *cosmic.StaticRoute) re
 			return fmt.Errorf("No Static Route ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		r, _, err := cs.VPC.GetStaticRouteByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		r, _, err := client.VPC.GetStaticRouteByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -74,7 +74,7 @@ func testAccCheckCosmicStaticRouteAttributes(route *cosmic.StaticRoute) resource
 }
 
 func testAccCheckCosmicStaticRouteDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_static_route" {
@@ -85,7 +85,7 @@ func testAccCheckCosmicStaticRouteDestroy(s *terraform.State) error {
 			return fmt.Errorf("No static route ID is set")
 		}
 
-		route, _, err := cs.VPC.GetStaticRouteByID(rs.Primary.ID)
+		route, _, err := client.VPC.GetStaticRouteByID(rs.Primary.ID)
 		if err == nil && route.Id != "" {
 			return fmt.Errorf("Static route %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_template.go
+++ b/cosmic/resource_cosmic_template.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -107,7 +106,7 @@ func resourceCosmicTemplate() *schema.Resource {
 }
 
 func resourceCosmicTemplateCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	if err := verifyTemplateParams(d); err != nil {
 		return err
@@ -122,19 +121,19 @@ func resourceCosmicTemplateCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Retrieve the os_type ID
-	ostypeid, e := retrieveID(cs, "os_type", d.Get("os_type").(string))
+	ostypeid, e := retrieveID(client, "os_type", d.Get("os_type").(string))
 	if e != nil {
 		return e.Error()
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(cs, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
 	if e != nil {
 		return e.Error()
 	}
 
 	// Create a new parameter struct
-	p := cs.Template.NewRegisterTemplateParams(
+	p := client.Template.NewRegisterTemplateParams(
 		displaytext,
 		d.Get("format").(string),
 		d.Get("hypervisor").(string),
@@ -165,7 +164,7 @@ func resourceCosmicTemplateCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Create the new template
-	r, err := cs.Template.RegisterTemplate(p)
+	r, err := client.Template.RegisterTemplate(p)
 	if err != nil {
 		return fmt.Errorf("Error creating template %s: %s", name, err)
 	}
@@ -196,10 +195,10 @@ func resourceCosmicTemplateCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceCosmicTemplateRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the template details
-	t, count, err := cs.Template.GetTemplateByID(d.Id(), "executable")
+	t, count, err := client.Template.GetTemplateByID(d.Id(), "executable")
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -229,11 +228,11 @@ func resourceCosmicTemplateRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceCosmicTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 	name := d.Get("name").(string)
 
 	// Create a new parameter struct
-	p := cs.Template.NewUpdateTemplateParams(d.Id())
+	p := client.Template.NewUpdateTemplateParams(d.Id())
 
 	if d.HasChange("name") {
 		p.SetName(name)
@@ -252,7 +251,7 @@ func resourceCosmicTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("os_type") {
-		ostypeid, e := retrieveID(cs, "os_type", d.Get("os_type").(string))
+		ostypeid, e := retrieveID(client, "os_type", d.Get("os_type").(string))
 		if e != nil {
 			return e.Error()
 		}
@@ -263,7 +262,7 @@ func resourceCosmicTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 		p.SetPasswordenabled(d.Get("password_enabled").(bool))
 	}
 
-	_, err := cs.Template.UpdateTemplate(p)
+	_, err := client.Template.UpdateTemplate(p)
 	if err != nil {
 		return fmt.Errorf("Error updating template %s: %s", name, err)
 	}
@@ -272,14 +271,14 @@ func resourceCosmicTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceCosmicTemplateDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.Template.NewDeleteTemplateParams(d.Id())
+	p := client.Template.NewDeleteTemplateParams(d.Id())
 
 	// Delete the template
 	log.Printf("[INFO] Deleting template: %s", d.Get("name").(string))
-	_, err := cs.Template.DeleteTemplate(p)
+	_, err := client.Template.DeleteTemplate(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_template.go
+++ b/cosmic/resource_cosmic_template.go
@@ -53,12 +53,6 @@ func resourceCosmicTemplate() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"is_dynamically_scalable": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -101,6 +95,14 @@ func resourceCosmicTemplate() *schema.Resource {
 				Optional: true,
 				Default:  300,
 			},
+
+			"zone": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: deprecatedZoneMsg(),
+			},
 		},
 	}
 }
@@ -127,7 +129,7 @@ func resourceCosmicTemplateCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", client.ZoneName)
 	if e != nil {
 		return e.Error()
 	}

--- a/cosmic/resource_cosmic_template_test.go
+++ b/cosmic/resource_cosmic_template_test.go
@@ -108,10 +108,6 @@ func testAccCheckCosmicTemplateBasicAttributes(template *cosmic.Template) resour
 			return fmt.Errorf("Bad os type: %s", template.Ostypename)
 		}
 
-		if template.Zonename != COSMIC_ZONE {
-			return fmt.Errorf("Bad zone: %s", template.Zonename)
-		}
-
 		return nil
 	}
 }
@@ -163,10 +159,7 @@ resource "cosmic_template" "foo" {
   hypervisor = "KVM"
   os_type    = "Other PV (64-bit)"
   url        = "http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
-  zone       = "%s"
-}`,
-	COSMIC_ZONE,
-)
+}`)
 
 var testAccCosmicTemplate_update = fmt.Sprintf(`
 resource "cosmic_template" "foo" {
@@ -176,9 +169,6 @@ resource "cosmic_template" "foo" {
   hypervisor              = "KVM"
   os_type                 = "Other PV (64-bit)"
   url                     = "http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
-  zone                    = "%s"
   is_dynamically_scalable = true
   password_enabled        = true
-}`,
-	COSMIC_ZONE,
-)
+}`)

--- a/cosmic/resource_cosmic_template_test.go
+++ b/cosmic/resource_cosmic_template_test.go
@@ -72,8 +72,8 @@ func testAccCheckCosmicTemplateExists(n string, template *cosmic.Template) resou
 			return fmt.Errorf("No template ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		tmpl, _, err := cs.Template.GetTemplateByID(rs.Primary.ID, "executable")
+		client := testAccProvider.Meta().(*CosmicClient)
+		tmpl, _, err := client.Template.GetTemplateByID(rs.Primary.ID, "executable")
 
 		if err != nil {
 			return err
@@ -136,7 +136,7 @@ func testAccCheckCosmicTemplateUpdatedAttributes(template *cosmic.Template) reso
 }
 
 func testAccCheckCosmicTemplateDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_template" {
@@ -147,7 +147,7 @@ func testAccCheckCosmicTemplateDestroy(s *terraform.State) error {
 			return fmt.Errorf("No template ID is set")
 		}
 
-		_, _, err := cs.Template.GetTemplateByID(rs.Primary.ID, "executable")
+		_, _, err := client.Template.GetTemplateByID(rs.Primary.ID, "executable")
 		if err == nil {
 			return fmt.Errorf("Template %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_vpc.go
+++ b/cosmic/resource_cosmic_vpc.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -82,18 +81,18 @@ func resourceCosmicVPC() *schema.Resource {
 }
 
 func resourceCosmicVPCCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	name := d.Get("name").(string)
 
 	// Retrieve the vpc_offering ID
-	vpcofferingid, e := retrieveID(cs, "vpc_offering", d.Get("vpc_offering").(string))
+	vpcofferingid, e := retrieveID(client, "vpc_offering", d.Get("vpc_offering").(string))
 	if e != nil {
 		return e.Error()
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(cs, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
 	if e != nil {
 		return e.Error()
 	}
@@ -105,7 +104,7 @@ func resourceCosmicVPCCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create a new parameter struct
-	p := cs.VPC.NewCreateVPCParams(
+	p := client.VPC.NewCreateVPCParams(
 		d.Get("cidr").(string),
 		displaytext.(string),
 		name,
@@ -132,7 +131,7 @@ func resourceCosmicVPCCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create the new VPC
-	r, err := cs.VPC.CreateVPC(p)
+	r, err := client.VPC.CreateVPC(p)
 	if err != nil {
 		return fmt.Errorf("Error creating VPC %s: %s", name, err)
 	}
@@ -143,10 +142,10 @@ func resourceCosmicVPCCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicVPCRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the VPC details
-	v, count, err := cs.VPC.GetVPCByID(d.Id())
+	v, count, err := client.VPC.GetVPCByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -166,7 +165,7 @@ func resourceCosmicVPCRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("syslogserverlist", v.Syslogserverlist)
 
 	// Get the VPC offering details
-	o, _, err := cs.VPC.GetVPCOfferingByID(v.Vpcofferingid)
+	o, _, err := client.VPC.GetVPCOfferingByID(v.Vpcofferingid)
 	if err != nil {
 		return err
 	}
@@ -175,12 +174,12 @@ func resourceCosmicVPCRead(d *schema.ResourceData, meta interface{}) error {
 	setValueOrID(d, "zone", v.Zonename, v.Zoneid)
 
 	// Create a new parameter struct
-	p := cs.PublicIPAddress.NewListPublicIpAddressesParams()
+	p := client.PublicIPAddress.NewListPublicIpAddressesParams()
 	p.SetVpcid(d.Id())
 	p.SetIssourcenat(true)
 
 	// Get the source NAT IP assigned to the VPC
-	l, err := cs.PublicIPAddress.ListPublicIpAddresses(p)
+	l, err := client.PublicIPAddress.ListPublicIpAddresses(p)
 	if err != nil {
 		return err
 	}
@@ -194,12 +193,12 @@ func resourceCosmicVPCRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicVPCUpdate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	name := d.Get("name").(string)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewUpdateVPCParams(d.Id())
+	p := client.VPC.NewUpdateVPCParams(d.Id())
 
 	// Check if the name is changed
 	if d.HasChange("name") {
@@ -240,7 +239,7 @@ func resourceCosmicVPCUpdate(d *schema.ResourceData, meta interface{}) error {
 	// Check if the VPC offering is changed
 	if d.HasChange("vpc_offering") {
 		// Retrieve the VPC offering ID
-		o, _, err := cs.VPC.GetVPCOfferingByName(d.Get("vpc_offering").(string))
+		o, _, err := client.VPC.GetVPCOfferingByName(d.Get("vpc_offering").(string))
 		if err != nil {
 			return err
 		}
@@ -249,7 +248,7 @@ func resourceCosmicVPCUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Update the VPC
-	_, err := cs.VPC.UpdateVPC(p)
+	_, err := client.VPC.UpdateVPC(p)
 	if err != nil {
 		return fmt.Errorf("Error updating name of VPC %s: %s", name, err)
 	}
@@ -258,13 +257,13 @@ func resourceCosmicVPCUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCosmicVPCDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPC.NewDeleteVPCParams(d.Id())
+	p := client.VPC.NewDeleteVPCParams(d.Id())
 
 	// Delete the VPC
-	_, err := cs.VPC.DeleteVPC(p)
+	_, err := client.VPC.DeleteVPC(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_vpc.go
+++ b/cosmic/resource_cosmic_vpc.go
@@ -72,9 +72,11 @@ func resourceCosmicVPC() *schema.Resource {
 			},
 
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: deprecatedZoneMsg(),
 			},
 		},
 	}
@@ -92,7 +94,7 @@ func resourceCosmicVPCCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Retrieve the zone ID
-	zoneid, e := retrieveID(client, "zone", d.Get("zone").(string))
+	zoneid, e := retrieveID(client, "zone", client.ZoneName)
 	if e != nil {
 		return e.Error()
 	}

--- a/cosmic/resource_cosmic_vpc_test.go
+++ b/cosmic/resource_cosmic_vpc_test.go
@@ -116,8 +116,6 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }`,
 	strings.ToLower(COSMIC_VPC_OFFERING),
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_vpc_test.go
+++ b/cosmic/resource_cosmic_vpc_test.go
@@ -48,8 +48,8 @@ func testAccCheckCosmicVPCExists(n string, vpc *cosmic.VPC) resource.TestCheckFu
 			return fmt.Errorf("No VPC ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		v, _, err := cs.VPC.GetVPCByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		v, _, err := client.VPC.GetVPCByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func testAccCheckCosmicVPCAttributes(vpc *cosmic.VPC) resource.TestCheckFunc {
 }
 
 func testAccCheckCosmicVPCDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_vpc" {
@@ -100,7 +100,7 @@ func testAccCheckCosmicVPCDestroy(s *terraform.State) error {
 			return fmt.Errorf("No VPC ID is set")
 		}
 
-		_, _, err := cs.VPC.GetVPCByID(rs.Primary.ID)
+		_, _, err := client.VPC.GetVPCByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("VPC %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_vpn_connection.go
+++ b/cosmic/resource_cosmic_vpn_connection.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -35,16 +34,16 @@ func resourceCosmicVPNConnection() *schema.Resource {
 }
 
 func resourceCosmicVPNConnectionCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewCreateVpnConnectionParams(
+	p := client.VPN.NewCreateVpnConnectionParams(
 		d.Get("customer_gateway_id").(string),
 		d.Get("vpn_gateway_id").(string),
 	)
 
 	// Create the new VPN Connection
-	v, err := cs.VPN.CreateVpnConnection(p)
+	v, err := client.VPN.CreateVpnConnection(p)
 	if err != nil {
 		return fmt.Errorf("Error creating VPN Connection: %s", err)
 	}
@@ -55,10 +54,10 @@ func resourceCosmicVPNConnectionCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceCosmicVPNConnectionRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the VPN Connection details
-	v, count, err := cs.VPN.GetVpnConnectionByID(d.Id())
+	v, count, err := client.VPN.GetVpnConnectionByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf("[DEBUG] VPN Connection does no longer exist")
@@ -76,13 +75,13 @@ func resourceCosmicVPNConnectionRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceCosmicVPNConnectionDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewDeleteVpnConnectionParams(d.Id())
+	p := client.VPN.NewDeleteVpnConnectionParams(d.Id())
 
 	// Delete the VPN Connection
-	_, err := cs.VPN.DeleteVpnConnection(p)
+	_, err := client.VPN.DeleteVpnConnection(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_vpn_connection_test.go
+++ b/cosmic/resource_cosmic_vpn_connection_test.go
@@ -91,14 +91,12 @@ resource "cosmic_vpc" "foo" {
   name         = "terraform-vpc-foo"
   cidr         = "10.0.10.0/22"
   vpc_offering = "%s"
-  zone         = "%s"
 }
 
 resource "cosmic_vpc" "bar" {
   name         = "terraform-vpc-bar"
   cidr         = "10.0.20.0/22"
   vpc_offering = "%s"
-  zone         = "%s"
 }
 
 resource "cosmic_vpn_gateway" "foo" {
@@ -138,9 +136,7 @@ resource "cosmic_vpn_connection" "bar-foo" {
 }
 `,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		rand,
 		rand,
 	)

--- a/cosmic/resource_cosmic_vpn_connection_test.go
+++ b/cosmic/resource_cosmic_vpn_connection_test.go
@@ -47,8 +47,8 @@ func testAccCheckCosmicVPNConnectionExists(n string, vpnConnection *cosmic.VpnCo
 			return fmt.Errorf("No VPN Connection ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		v, _, err := cs.VPN.GetVpnConnectionByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		v, _, err := client.VPN.GetVpnConnectionByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -65,7 +65,7 @@ func testAccCheckCosmicVPNConnectionExists(n string, vpnConnection *cosmic.VpnCo
 }
 
 func testAccCheckCosmicVPNConnectionDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_vpn_connection" {
@@ -76,7 +76,7 @@ func testAccCheckCosmicVPNConnectionDestroy(s *terraform.State) error {
 			return fmt.Errorf("No VPN Connection ID is set")
 		}
 
-		_, _, err := cs.VPN.GetVpnConnectionByID(rs.Primary.ID)
+		_, _, err := client.VPN.GetVpnConnectionByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("VPN Connection %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_vpn_customer_gateway.go
+++ b/cosmic/resource_cosmic_vpn_customer_gateway.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -74,10 +73,10 @@ func resourceCosmicVPNCustomerGateway() *schema.Resource {
 }
 
 func resourceCosmicVPNCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewCreateVpnCustomerGatewayParams(
+	p := client.VPN.NewCreateVpnCustomerGatewayParams(
 		createCidrList(d.Get("cidr_list").(*schema.Set)),
 		d.Get("esp_policy").(string),
 		d.Get("gateway").(string),
@@ -100,7 +99,7 @@ func resourceCosmicVPNCustomerGatewayCreate(d *schema.ResourceData, meta interfa
 	}
 
 	// Create the new VPN Customer Gateway
-	v, err := cs.VPN.CreateVpnCustomerGateway(p)
+	v, err := client.VPN.CreateVpnCustomerGateway(p)
 	if err != nil {
 		return fmt.Errorf("Error creating VPN Customer Gateway %s: %s", d.Get("name").(string), err)
 	}
@@ -111,10 +110,10 @@ func resourceCosmicVPNCustomerGatewayCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceCosmicVPNCustomerGatewayRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the VPN Customer Gateway details
-	v, count, err := cs.VPN.GetVpnCustomerGatewayByID(d.Id())
+	v, count, err := client.VPN.GetVpnCustomerGatewayByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -140,10 +139,10 @@ func resourceCosmicVPNCustomerGatewayRead(d *schema.ResourceData, meta interface
 }
 
 func resourceCosmicVPNCustomerGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewUpdateVpnCustomerGatewayParams(
+	p := client.VPN.NewUpdateVpnCustomerGatewayParams(
 		createCidrList(d.Get("cidr_list").(*schema.Set)),
 		d.Get("esp_policy").(string),
 		d.Get("gateway").(string),
@@ -167,7 +166,7 @@ func resourceCosmicVPNCustomerGatewayUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	// Update the VPN Customer Gateway
-	_, err := cs.VPN.UpdateVpnCustomerGateway(p)
+	_, err := client.VPN.UpdateVpnCustomerGateway(p)
 	if err != nil {
 		return fmt.Errorf("Error updating VPN Customer Gateway %s: %s", d.Get("name").(string), err)
 	}
@@ -176,13 +175,13 @@ func resourceCosmicVPNCustomerGatewayUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceCosmicVPNCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewDeleteVpnCustomerGatewayParams(d.Id())
+	p := client.VPN.NewDeleteVpnCustomerGatewayParams(d.Id())
 
 	// Delete the VPN Customer Gateway
-	_, err := cs.VPN.DeleteVpnCustomerGateway(p)
+	_, err := client.VPN.DeleteVpnCustomerGateway(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_vpn_customer_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_customer_gateway_test.go
@@ -56,8 +56,8 @@ func testAccCheckCosmicVPNCustomerGatewayExists(n string, vpnCustomerGateway *co
 			return fmt.Errorf("No VPN CustomerGateway ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		v, _, err := cs.VPN.GetVpnCustomerGatewayByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		v, _, err := client.VPN.GetVpnCustomerGatewayByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -93,7 +93,7 @@ func testAccCheckCosmicVPNCustomerGatewayAttributes(vpnCustomerGateway *cosmic.V
 }
 
 func testAccCheckCosmicVPNCustomerGatewayDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_vpn_customer_gateway" {
@@ -104,7 +104,7 @@ func testAccCheckCosmicVPNCustomerGatewayDestroy(s *terraform.State) error {
 			return fmt.Errorf("No VPN Customer Gateway ID is set")
 		}
 
-		_, _, err := cs.VPN.GetVpnCustomerGatewayByID(rs.Primary.ID)
+		_, _, err := client.VPN.GetVpnCustomerGatewayByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("VPN Customer Gateway %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resource_cosmic_vpn_customer_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_customer_gateway_test.go
@@ -119,14 +119,12 @@ resource "cosmic_vpc" "foo" {
   name         = "terraform-vpc-foo"
   cidr         = "10.0.10.0/22"
   vpc_offering = "%s"
-  zone         = "%s"
 }
 
 resource "cosmic_vpc" "bar" {
   name         = "terraform-vpc-bar"
   cidr         = "10.0.20.0/22"
   vpc_offering = "%s"
-  zone         = "%s"
 }
 
 resource "cosmic_vpn_gateway" "foo" {
@@ -155,9 +153,7 @@ resource "cosmic_vpn_customer_gateway" "bar" {
   ipsec_psk  = "terraform"
 }`,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		COSMIC_VPC_OFFERING,
-		COSMIC_ZONE,
 		rand,
 		rand,
 	)

--- a/cosmic/resource_cosmic_vpn_gateway.go
+++ b/cosmic/resource_cosmic_vpn_gateway.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -34,13 +33,13 @@ func resourceCosmicVPNGateway() *schema.Resource {
 }
 
 func resourceCosmicVPNGatewayCreate(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	vpcid := d.Get("vpc_id").(string)
-	p := cs.VPN.NewCreateVpnGatewayParams(vpcid)
+	p := client.VPN.NewCreateVpnGatewayParams(vpcid)
 
 	// Create the new VPN Gateway
-	v, err := cs.VPN.CreateVpnGateway(p)
+	v, err := client.VPN.CreateVpnGateway(p)
 	if err != nil {
 		return fmt.Errorf("Error creating VPN Gateway for VPC ID %s: %s", vpcid, err)
 	}
@@ -51,10 +50,10 @@ func resourceCosmicVPNGatewayCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCosmicVPNGatewayRead(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Get the VPN Gateway details
-	v, count, err := cs.VPN.GetVpnGatewayByID(d.Id())
+	v, count, err := client.VPN.GetVpnGatewayByID(d.Id())
 	if err != nil {
 		if count == 0 {
 			log.Printf(
@@ -73,13 +72,13 @@ func resourceCosmicVPNGatewayRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceCosmicVPNGatewayDelete(d *schema.ResourceData, meta interface{}) error {
-	cs := meta.(*cosmic.CosmicClient)
+	client := meta.(*CosmicClient)
 
 	// Create a new parameter struct
-	p := cs.VPN.NewDeleteVpnGatewayParams(d.Id())
+	p := client.VPN.NewDeleteVpnGatewayParams(d.Id())
 
 	// Delete the VPN Gateway
-	_, err := cs.VPN.DeleteVpnGateway(p)
+	_, err := client.VPN.DeleteVpnGateway(p)
 	if err != nil {
 		// This is a very poor way to be told the ID does no longer exist :(
 		if strings.Contains(err.Error(), fmt.Sprintf(

--- a/cosmic/resource_cosmic_vpn_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_gateway_test.go
@@ -89,12 +89,10 @@ resource "cosmic_vpc" "foo" {
   cidr           = "10.0.10.0/22"
   vpc_offering   = "%s"
   network_domain = "terraform-domain"
-  zone           = "%s"
 }
 
 resource "cosmic_vpn_gateway" "foo" {
   vpc_id = "${cosmic_vpc.foo.id}"
 }`,
 	COSMIC_VPC_OFFERING,
-	COSMIC_ZONE,
 )

--- a/cosmic/resource_cosmic_vpn_gateway_test.go
+++ b/cosmic/resource_cosmic_vpn_gateway_test.go
@@ -44,8 +44,8 @@ func testAccCheckCosmicVPNGatewayExists(n string, vpnGateway *cosmic.VpnGateway)
 			return fmt.Errorf("No VPN Gateway ID is set")
 		}
 
-		cs := testAccProvider.Meta().(*cosmic.CosmicClient)
-		v, _, err := cs.VPN.GetVpnGatewayByID(rs.Primary.ID)
+		client := testAccProvider.Meta().(*CosmicClient)
+		v, _, err := client.VPN.GetVpnGatewayByID(rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -62,7 +62,7 @@ func testAccCheckCosmicVPNGatewayExists(n string, vpnGateway *cosmic.VpnGateway)
 }
 
 func testAccCheckCosmicVPNGatewayDestroy(s *terraform.State) error {
-	cs := testAccProvider.Meta().(*cosmic.CosmicClient)
+	client := testAccProvider.Meta().(*CosmicClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cosmic_vpn_gateway" {
@@ -73,7 +73,7 @@ func testAccCheckCosmicVPNGatewayDestroy(s *terraform.State) error {
 			return fmt.Errorf("No VPN Gateway ID is set")
 		}
 
-		_, _, err := cs.VPN.GetVpnGatewayByID(rs.Primary.ID)
+		_, _, err := client.VPN.GetVpnGatewayByID(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("VPN Gateway %s still exists", rs.Primary.ID)
 		}

--- a/cosmic/resources.go
+++ b/cosmic/resources.go
@@ -37,7 +37,7 @@ func setValueOrID(d *schema.ResourceData, key string, value string, id string) {
 	}
 }
 
-func retrieveID(cs *cosmic.CosmicClient, name string, value string, opts ...cosmic.OptionFunc) (id string, e *retrieveError) {
+func retrieveID(client *CosmicClient, name string, value string, opts ...cosmic.OptionFunc) (id string, e *retrieveError) {
 	// If the supplied value isn't a ID, try to retrieve the ID ourselves
 	if cosmic.IsID(value) {
 		return value, nil
@@ -49,19 +49,19 @@ func retrieveID(cs *cosmic.CosmicClient, name string, value string, opts ...cosm
 	var err error
 	switch name {
 	case "disk_offering":
-		id, _, err = cs.DiskOffering.GetDiskOfferingID(value)
+		id, _, err = client.DiskOffering.GetDiskOfferingID(value)
 	case "service_offering":
-		id, _, err = cs.ServiceOffering.GetServiceOfferingID(value)
+		id, _, err = client.ServiceOffering.GetServiceOfferingID(value)
 	case "network_offering":
-		id, _, err = cs.NetworkOffering.GetNetworkOfferingID(value)
+		id, _, err = client.NetworkOffering.GetNetworkOfferingID(value)
 	case "vpc_offering":
-		id, _, err = cs.VPC.GetVPCOfferingID(value)
+		id, _, err = client.VPC.GetVPCOfferingID(value)
 	case "zone":
-		id, _, err = cs.Zone.GetZoneID(value)
+		id, _, err = client.Zone.GetZoneID(value)
 	case "os_type":
-		p := cs.GuestOS.NewListOsTypesParams()
+		p := client.GuestOS.NewListOsTypesParams()
 		p.SetDescription(value)
-		l, e := cs.GuestOS.ListOsTypes(p)
+		l, e := client.GuestOS.ListOsTypes(p)
 		if e != nil {
 			err = e
 			break
@@ -83,7 +83,7 @@ func retrieveID(cs *cosmic.CosmicClient, name string, value string, opts ...cosm
 	return id, nil
 }
 
-func retrieveTemplateID(cs *cosmic.CosmicClient, zoneid, value string) (id string, e *retrieveError) {
+func retrieveTemplateID(client *CosmicClient, zoneid, value string) (id string, e *retrieveError) {
 	// If the supplied value isn't a ID, try to retrieve the ID ourselves
 	if cosmic.IsID(value) {
 		return value, nil
@@ -92,7 +92,7 @@ func retrieveTemplateID(cs *cosmic.CosmicClient, zoneid, value string) (id strin
 	log.Printf("[DEBUG] Retrieving ID of template: %s", value)
 
 	// Ignore count, since an error is returned if there is no exact match
-	id, _, err := cs.Template.GetTemplateID(value, "executable", zoneid)
+	id, _, err := client.Template.GetTemplateID(value, "executable", zoneid)
 	if err != nil {
 		return id, &retrieveError{name: "template", value: value, err: err}
 	}
@@ -121,9 +121,9 @@ func Retry(n int, f RetryFunc) (interface{}, error) {
 	return nil, lastErr
 }
 
-func isCosmic(cs *cosmic.CosmicClient) bool {
-	l := cs.Configuration.NewListCapabilitiesParams()
-	c, err := cs.Configuration.ListCapabilities(l)
+func isCosmic(client *CosmicClient) bool {
+	l := client.Configuration.NewListCapabilitiesParams()
+	c, err := client.Configuration.ListCapabilities(l)
 	if err != nil {
 		fmt.Errorf("Unable to retrieve capabilities: %s", err)
 		return false

--- a/cosmic/tags.go
+++ b/cosmic/tags.go
@@ -3,7 +3,6 @@ package cosmic
 import (
 	"log"
 
-	"github.com/MissionCriticalCloud/go-cosmic/v6/cosmic"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -18,7 +17,7 @@ func tagsSchema() *schema.Schema {
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-func setTags(cs *cosmic.CosmicClient, d *schema.ResourceData, resourcetype string) error {
+func setTags(client *CosmicClient, d *schema.ResourceData, resourcetype string) error {
 	oraw, nraw := d.GetChange("tags")
 	o := oraw.(map[string]interface{})
 	n := nraw.(map[string]interface{})
@@ -30,9 +29,9 @@ func setTags(cs *cosmic.CosmicClient, d *schema.ResourceData, resourcetype strin
 	// First remove any obsolete tags
 	if len(remove) > 0 {
 		log.Printf("[DEBUG] Removing tags: %v from %s", remove, d.Id())
-		p := cs.Resourcetags.NewDeleteTagsParams([]string{d.Id()}, resourcetype)
+		p := client.Resourcetags.NewDeleteTagsParams([]string{d.Id()}, resourcetype)
 		p.SetTags(remove)
-		_, err := cs.Resourcetags.DeleteTags(p)
+		_, err := client.Resourcetags.DeleteTags(p)
 		if err != nil {
 			return err
 		}
@@ -41,8 +40,8 @@ func setTags(cs *cosmic.CosmicClient, d *schema.ResourceData, resourcetype strin
 	// Then add any new tags
 	if len(create) > 0 {
 		log.Printf("[DEBUG] Creating tags: %v for %s", create, d.Id())
-		p := cs.Resourcetags.NewCreateTagsParams([]string{d.Id()}, resourcetype, create)
-		_, err := cs.Resourcetags.CreateTags(p)
+		p := client.Resourcetags.NewCreateTagsParams([]string{d.Id()}, resourcetype, create)
+		_, err := client.Resourcetags.CreateTags(p)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/MissionCriticalCloud/terraform-provider-cosmic
 go 1.12
 
 require (
+	github.com/MissionCriticalCloud/go-cosmic v6.2.6+incompatible
 	github.com/MissionCriticalCloud/go-cosmic/v6 v6.2.8
 	github.com/go-ini/ini v1.41.0
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MissionCriticalCloud/go-cosmic v6.2.6+incompatible h1:J8sN+/TYyKQJcQqWcDnOy5OM+hXQtiotTDvjeUPt6FI=
+github.com/MissionCriticalCloud/go-cosmic v6.2.6+incompatible/go.mod h1:DFavzFQBiLwlyfp0i73GjpKU5GNouDKUfzCL+fMzpKc=
 github.com/MissionCriticalCloud/go-cosmic/v6 v6.2.8 h1:zr0CBe+oqFsbVUjULWfhGivm6aKrMKncAZvSDS8Tua8=
 github.com/MissionCriticalCloud/go-cosmic/v6 v6.2.8/go.mod h1:K/NK6dPjUBesEKUkfSZXYckHUv4FYPd4oKl42BO4eBI=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -28,6 +28,7 @@ provider "cosmic" {
   api_url    = "${var.cosmic_api_url}"
   api_key    = "${var.cosmic_api_key}"
   secret_key = "${var.cosmic_secret_key}"
+  zone       = "${var.cosmic_zone}"
 }
 
 # Create a web server
@@ -49,8 +50,11 @@ The following arguments are supported:
 * `secret_key` - (Optional) This is the Cosmic secret key. It can also be
   sourced from the `COSMIC_SECRET_KEY` environment variable.
 
+* `zone` - (Optional) This is the Cosmic zone It can also be
+  sourced from the `COSMIC_ZONE` environment variable.
+
 * `config` - (Optional) The path to a `CloudMonkey` config file. If set the API
-  URL, key and secret will be retrieved from this file. It can also be
+  URL, key, secret and zone will be retrieved from this file. It can also be
   sourced from the `COSMIC_CONFIG` environment variable.
 
 * `profile` - (Optional) Used together with the `config` option. Specifies which


### PR DESCRIPTION
It can be confusing for people when to set the zone and when not to, this sets the zone via the provider config so users do not need to worry about setting it for specific resources.